### PR TITLE
Update references to github.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ will be placed within your working directory.
 To check out the latest LMP subscriber continuous release:
 
 ```
-repo init -u https://source.foundries.io/lmp-manifest
+repo init -u https://github.com/foundriesio/lmp-manifest
 ```
-
-When prompted, configure Repo with your real name and email address.
 
 A successful initialization will end with a message stating that Repo
 is initialized in your working directory. Your client directory should

--- a/default.xml
+++ b/default.xml
@@ -10,7 +10,7 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="6e2ad96fce82bb7a12bba506ac15511752c4f007" />
   <project name="meta-intel" path="layers/meta-intel" revision="f7a9272983abac3a5269286f8d214765f49af656" />
   <project name="meta-linaro" path="layers/meta-linaro" revision="edb7ffc2a121df7596385595abe75180296103e0" />
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="062c4e5920d3ac321638fc90ad866e4781c2da86" />
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="853cd7966e8a31fdee54eb1f827e23d55d01b575" />
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="9a64b3805de82c813d89de92163129a84c2ebf97" />
   <project name="meta-qcom" path="layers/meta-qcom" revision="a38028357962542f80a3075b7ec2e089fcc5d321" />
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="c8a05f2fcf17ca2556f8a56086ea36da2e777d0f" />

--- a/default.xml
+++ b/default.xml
@@ -1,16 +1,16 @@
 <manifest>
-  <remote fetch="https://source.foundries.io" name="subscriber-microplatforms" />
+  <remote fetch="https://github.com/foundriesio" name="fio" />
   <remote fetch="https://source.foundries.io/lmp-mirrors" name="lmp-mirrors" />
-  
+
   <default remote="lmp-mirrors" revision="master" sync-j="4" />
-  
+
   <project name="bitbake" revision="7414b3537e8adfb41a9581d70bf8296c4f7d38c0" />
   <project name="meta-96boards" path="layers/meta-96boards" revision="10af9ab9265184ae90e0b62e9de0594119159922" />
   <project name="meta-freescale" path="layers/meta-freescale" revision="15a354ee592866a61a893562760ef84bf8fe5e4d" />
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="6e2ad96fce82bb7a12bba506ac15511752c4f007" />
   <project name="meta-intel" path="layers/meta-intel" revision="f7a9272983abac3a5269286f8d214765f49af656" />
   <project name="meta-linaro" path="layers/meta-linaro" revision="edb7ffc2a121df7596385595abe75180296103e0" />
-  <project name="meta-lmp" path="layers/meta-lmp" remote="subscriber-microplatforms" revision="062c4e5920d3ac321638fc90ad866e4781c2da86" />
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="062c4e5920d3ac321638fc90ad866e4781c2da86" />
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="9a64b3805de82c813d89de92163129a84c2ebf97" />
   <project name="meta-qcom" path="layers/meta-qcom" revision="a38028357962542f80a3075b7ec2e089fcc5d321" />
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="c8a05f2fcf17ca2556f8a56086ea36da2e777d0f" />


### PR DESCRIPTION
The LMP source has moved to GitHub and this fixes our Android repo
setup logic.

Signed-off-by: Andy Doan <andy@foundries.io>