### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,7 +10,7 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="56021ac593b6a3f4ed7be351d8f4358a19d8e87a" />
   <project name="meta-intel" path="layers/meta-intel" revision="5bd939d746126a22af5e52139a54d1696578f902" />
   <project name="meta-linaro" path="layers/meta-linaro" revision="edb7ffc2a121df7596385595abe75180296103e0" />
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="b58f0fba05f7c69c75bc1cda3174ebdbbfe99190" />
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="ba6c4049f9a6701f832695de597cdec3b9cb0dfc" />
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="ff6bead1624a1e261408516b3d064a04aab5f592" />
   <project name="meta-qcom" path="layers/meta-qcom" revision="b03212707cec5c49bde4e1d6afb58513e1731318" />
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="1aa973ce382caf2d4aff8164cd91c435d1aa86a9" />


### PR DESCRIPTION
Relevant changes:
- 9cc89ab raspberrypi: enable support for fitImage
- 509cb3e linux-lmp: bump kernel for rpi-7inch-flip overlay
- 120b7f4 colibri-imx7: enable support for fitImage
- 4257c95 cl-som-imx7: enable support for fitImage
- 7ba47f3 cubox-i: enable support for fitImage
- 6acf05a dragonboard-820c: enable support for fitImage
- bd4c441 u-boot: db820c: enable support for fitImage
- 894554d dragonboard-410c: enable support for fitImage
- ec30843 beaglebone-yocto: enable support for fitImage

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>