### PR TITLE
conf/local.conf: disable SSTATE_MIRRORS by default

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -36,9 +36,9 @@ PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
 # would contain the sstate-cache results from previous builds (possibly from other
 # machines). This variable works like fetcher MIRRORS/PREMIRRORS and points to the
 # cache locations to check for the shared objects.
-SSTATE_MIRRORS ?= "\
-file://.* https://storage.googleapis.com/lmp-cache/sstate-cache/PATH \n \
-"
+#SSTATE_MIRRORS ?= "\
+#file://.* https://storage.googleapis.com/lmp-cache/sstate-cache/PATH \n \
+#"
 
 # enable PR service on build machine itself
 # its good for a case when this is the only builder


### PR DESCRIPTION
Unfortunately the sstate search and fetch performance is far from ideal,
forcing the user to wait a considerable amount of time before starting
the actual build process, so disable SSTATE_MIRRORS by default until a
better solution is found.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>