### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,7 +10,7 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="3b60f3e31a9aba22bd635d7f0d34fd2304296bdc" />
   <project name="meta-intel" path="layers/meta-intel" revision="5bda3104f9c3c117c2ae90ce74307c3d1feffa66" />
   <project name="meta-linaro" path="layers/meta-linaro" revision="a6db64d7e165f8850877721df43d57600f3761d7" />
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="d661def1682fc0bdde9d0a53e827bc6fd5572a4d" />
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="8e54e70cc76be3b47c4d9104fa228d5178c89f83" />
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="0b5dbf35b44e5e738d1ba5ae48468a1dbafd6649" />
   <project name="meta-qcom" path="layers/meta-qcom" revision="a9f51f0bfe41e518136995e43ffb78e815047332" />
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="60dbfd25443754690f834afe30e7a6dca46a40da" />


### PR DESCRIPTION
Relevant changes:
- e76d831 u-boot-ostree-scr/apalis-imx6: use upstream variable for fdt
- 6134385 u-boot-toradex: use imx6q-apalis-ixora-v1.1.dtb by default on apalis-imx6
- 64c45a2 u-boot-toradex: split patches per targets
- ed54914 lmp-machine-custom: remove nand/emmc comment for apalis imx6
- 2900e34 recipes-kernel/linux: bump kmeta sha
- 2dfea9a u-boot-toradex: apalis-imx6: use distro_bootcmd by default
- 5a398c8 u-boot-script-toradex: add apalis-imx6 files
- 6a3f2a1 toradex: add apalis-imx6 configuration

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>