### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="7f3a9bf2339e2413ba38e6243cd8116d65a27b2a" />
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="cc6475e9a620da6fce022bf5cc59b6a8c8fcd81d" />
   <project name="meta-intel" path="layers/meta-intel" revision="e92b588839dd40e561e201f6fc21df31db202508" />
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4e893327c60a28839e88cc953eac78ddf98ef32f" />
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4194279a50854653cdb630b25af6dfc1cfc598ce" />
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="e71751bf3cd209f07b986bb2c6289902546d3666" />
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="18544d447173ca762a0661fd0fe8ba72b21d0579" />
   <project name="meta-riscv" path="layers/meta-riscv" revision="cb0857efe5fb3550c036ee05378e5c4098099914" />


### PR DESCRIPTION
Relevant changes:
- 4194279 aktualizr: lite: fix incorrect storing of ecu hwid

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>