### PR TITLE
Pull in new meta-lmp

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,12 +8,12 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="7f3a9bf2339e2413ba38e6243cd8116d65a27b2a" />
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="cc6475e9a620da6fce022bf5cc59b6a8c8fcd81d" />
   <project name="meta-intel" path="layers/meta-intel" revision="e92b588839dd40e561e201f6fc21df31db202508" />
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4194279a50854653cdb630b25af6dfc1cfc598ce" />
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="03ecda1ffd61d6f3116e7223bedb305777f28960" />
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="e71751bf3cd209f07b986bb2c6289902546d3666" />
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="18544d447173ca762a0661fd0fe8ba72b21d0579" />
   <project name="meta-riscv" path="layers/meta-riscv" revision="cb0857efe5fb3550c036ee05378e5c4098099914" />
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="3d920444e433ceddecb7809da0ebab278d57e1ef" />
-  <project name="meta-updater" path="layers/meta-updater" revision="f13dd347107648176bc54458ce65c9cdf68730c8" />
+  <project name="meta-updater" path="layers/meta-updater" revision="b056b701b29fa3a2befaf5abc621e43bc8459c70" />
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="c6e7bf94debb7bdd7a2b52b222a4b0da732a24b4" />
   <project name="meta-yocto" path="layers/meta-yocto" revision="f19f3a7a5286cabf42a0f6d0ea8f7841dc043324">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment" />


### PR DESCRIPTION
This pull in the latest meta-lmp as well as updates to aktualizr
that rebase cleanly on top of it.

Changes to meta-lmp:

b056b70 (HEAD -> master, origin/master, origin/HEAD) Merge pull request #591 from advancedtelematic/fix/ip-secondary-test/wait-until-provisioned
620152f Use --wait-until-provisioned option while getting aktualizr status in the ip secondary tests
abfc287 Merge pull request #590 from advancedtelematic/fix/OTA-3419/garage-sign-expiry
74d9d16 README: new section for garage-sign.
08759ff Use a default expiry of one month if nothing is specified.
8434da1 aktualizr: latest garage-sign with expiration support.
3bc6500 Merge pull request #587 from advancedtelematic/fix/grub-ostree
f865c40 Expose OSTREE_BOOT_PARTITION in do_image_ota
e8ec175 Merge pull request #586 from advancedtelematic/fix/ptest-qa
1b46307 Fix error during package_qa with aktualizr-ptest
8b4f0cf Fix/ostree branchname 2 (#585)
261c28a Do not export anything in sota.bbclass
4f90284 Revert "Move OSTREE_BRANCHNAME to image_types_ostree.bbclass."
057fdb0 Merge pull request #532 from advancedtelematic/feat/OTA-2666/garage-tools-mutual-tls
8fa3a60 Bump aktualizr and garage-sign versions to the latest.
9921803 Merge pull request #578 from advancedtelematic/fix/qemucommand
c6ad1d2 qemucommand.py: redirect qemu monitor to null chardev
b8215f4 Merge pull request #572 from advancedtelematic/test/ota-3064/test-for-setting-custom-hardware-id
a2fc4db Test for setting hwid
558c25c Revert "Do not create connman's resolv.conf symlink at boot" (#577)
1a3c0f0 Revert "Do not create connman's resolv.conf symlink at boot"
f348e80 Merge pull request #574 from advancedtelematic/connman-fix-master
8b5e97c Bump aktualizr
36f3119 More helpful error message when running qemu
8180fe8 Add bugfix service for old connman to systemd-networkd
2c72b0c Do not create connman's resolv.conf symlink at boot
cf559d5 Merge pull request #568 from advancedtelematic/feat/OTA-3115/Dont-patch-credentials
672fcc5 Dont patch credentials

Signed-off-by: Andy Doan <andy@foundries.io>