### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="7f3a9bf2339e2413ba38e6243cd8116d65a27b2a" />
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="cc6475e9a620da6fce022bf5cc59b6a8c8fcd81d" />
   <project name="meta-intel" path="layers/meta-intel" revision="e92b588839dd40e561e201f6fc21df31db202508" />
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4194279a50854653cdb630b25af6dfc1cfc598ce" />
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="d0cbaddcb4e00f5e122753a715db4689db929c31" />
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="e71751bf3cd209f07b986bb2c6289902546d3666" />
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="18544d447173ca762a0661fd0fe8ba72b21d0579" />
   <project name="meta-riscv" path="layers/meta-riscv" revision="cb0857efe5fb3550c036ee05378e5c4098099914" />


### PR DESCRIPTION
Relevant changes:
- d0cbadd optee: always set default value to OPTEE_TA_SIGN_KEY
- 48a2eca images: implement feature includes
- a850de6 support: add net-queue-pfifo-fast package
- dd8b910 support: add hang/crash helper
- 42d4bc4 support: add sbin-path helper
- bfc6222 support: add ostree pending reboot service
- b2c5b88 support: add bt-6lowpan-setup package
- d295128 optee-os: support custom TA_SIGN_KEY
- 5468a3c u-boot-ostree-scr-fit: add recipe for u-boot scr in fit format
- 13741ff Add sdimage-imx6dq-spl-fit-sota.wks
- c063db5 uboot-fitimage: add bbclass for spl/u-boot fitimage support
- ed45feb optee-test: fixing cross build on arm32
- c728033 optee-os: add support for cubox-i
- 1ce7b86 optee-os: deploy tee-init_load_addr
- f34c738 lmp-image-common: install crucible on imx targets
- 324a068 crucible: add recipe
- f78842e linux-lmp: bump kmeta sha
- e870dbd lmp-machine-custom: add OSTREE kernel args for i.MX7ULP
- 148a0a5 lmp-machine-custom: split out i.MX OSTREE kernel args
- 3f193fd jool: update to v4.0.4 release

Change-Id: I5323f0f3ebfdbc07704d40bdab970d7f03f9fe79
Signed-off-by: Michael Scott <mike@foundries.io>