### PR TITLE
setup-environment-internal: allow DISTRO to be overridden

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -45,7 +45,7 @@ elif [ -n "$BASH_VERSION" ]; then
 fi
 
 # Set default distro to Linux microPlatform
-DISTRO=lmp
+DISTRO="${DISTRO-lmp}"
 
 usage () {
     cat <<EOF


### PR DESCRIPTION
Signed-off-by: Michael Scott <mike@foundries.io>