### PR TITLE
Initial changes for 49

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -9,7 +9,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="a1b81241bc3ed8efcbcf5395db0c3eb5b0834d72"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="9a96fb93f100f067729dce2b9d794333fcf1f627"/>
   <project name="meta-intel" path="layers/meta-intel" revision="655dfaec95196b9c0e15d34f490e4a51a7d501e3"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c36773c6ef3a0e31882f0bd5ffd72e2a46efa893"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="0c9f7b853ded6a8345bd814789b331dcf994dcb3"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a61ef2c75f1b731179aacf0c98c523d5a92052c2"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="d34e054d5140792150d2a7ae3c0264eb254c8aa3"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="270c8cb7c110cae7bbff88bab677167350d05b6c"/>

--- a/default.xml
+++ b/default.xml
@@ -10,7 +10,7 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="9a96fb93f100f067729dce2b9d794333fcf1f627"/>
   <project name="meta-intel" path="layers/meta-intel" revision="e9957d290ee2c3d32874f8ca94fe9519a30ac18f"/>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c36773c6ef3a0e31882f0bd5ffd72e2a46efa893"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="19528ba2a6014ebe32b7a3d3099b037330228b88"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="a61ef2c75f1b731179aacf0c98c523d5a92052c2"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="d34e054d5140792150d2a7ae3c0264eb254c8aa3"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="270c8cb7c110cae7bbff88bab677167350d05b6c"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="3d920444e433ceddecb7809da0ebab278d57e1ef"/>

--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
   <project name="bitbake" revision="9a1bf4ba9ec00c2a222d820f8f83d1f056b021d6"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="a1b81241bc3ed8efcbcf5395db0c3eb5b0834d72"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="9a96fb93f100f067729dce2b9d794333fcf1f627"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="e9957d290ee2c3d32874f8ca94fe9519a30ac18f"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="655dfaec95196b9c0e15d34f490e4a51a7d501e3"/>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c36773c6ef3a0e31882f0bd5ffd72e2a46efa893"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a61ef2c75f1b731179aacf0c98c523d5a92052c2"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="d34e054d5140792150d2a7ae3c0264eb254c8aa3"/>

--- a/default.xml
+++ b/default.xml
@@ -20,5 +20,5 @@
   <project name="meta-yocto" path="layers/meta-yocto" revision="a058af8c82738620c9aab784118fd9680abfcf55">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>
   </project>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="86b8a1d534bfcd70775c6e2b59eabe10de29f526"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="aff2d1264030a8061fc1b31dae0f369bfd76826b"/>
 </manifest>


### PR DESCRIPTION
Meta-intel, oe-core and meta-oe updates, besides meta-lmp to get in sync with the rest.

Brings latest lmp-device-register and also the lmp-base distro definition.