### PR TITLE
default.xml: update meta-openembedded layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,7 +10,7 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="aea3771baa77e74762358ceb673d407e36637e5f"/>
   <project name="meta-intel" path="layers/meta-intel" revision="f247a8a3b6e75b67f9de7e21fbecf7834125b174"/>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="35841f3130d35208370e69a69aa4508665fcaab2"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="1bfaa2e63a184e21a2db5c286444828d5948a8b4"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="e99bcd36e0275a093f3b12807b154105eb0a27ca"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="cee2557dc872ddaf721e6badb981c7772503f8ea"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="0d5a7c956fcc2ccd56d477ea546b272af4db4c37"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="069a9fa127a7fefc7cf5ffaa51c9771a624eccf5"/>


### PR DESCRIPTION
Relevant changes:
- e99bcd36e libmbim: upgrade 1.18.0 -> 1.20.0
- 329eeed42 nlohmann-fifo: Add recipe
- c3667e93c python3-google-api-python-client: Initial commit of 1.7.11
- 25aabc666 python3-msk: Initial commit of version 0.3.13
- b67ed5b71 python3-monotonic: Initial commit of version 1.5
- 7d4632fad libiio: bump to version 0.18+
- 6af155513 libiio: allow python3 bindings to be built
- c259bc3af Revert "libiio: fix build of python bindins"
- 9d738acfd lvm2/libdevmapper: 2.03.02 -> 2.03.05
- 9f9f9f868 tremor: Clarify BSD license variant
- 6ec4677b2 libmpdclient: Clarify BSD license variant
- 647859d98 xfce4-wavelan-plugin: Clarify BSD license variant
- dfcdae674 xfce4-diskperf-plugin: Clarify BSD license variant
- 2a8c5c3f8 xfce4-mpc-plugin: Clarify BSD license variant
- d8e71b65a mycroft: Run the files from /var
- 74aa0be63 mycroft: Bump to 19.8.1
- c50a0cd12 rsyslog: fix CVE-2019-17041
- 02fa65c8e python-xxhash: upgrade 1.4.1 -> 1.4.2
- a60518739 python-pytz: upgrade 2019.2 -> 2019.3
- a41e89f56 python-pytest: upgrade 5.1.3 -> 5.2.1
- 2cdaf5294 python-pyasn1-modules: upgrade 0.2.6 -> 0.2.7
- a5c5c1b6e python-pip: upgrade 19.2.3 -> 19.3
- d33101ac2 nvme-cli: defer host ID generation to post installation
- bac507300 python-paste: upgrade 3.2.1 -> 3.2.2
- 699cd1602 strongswan: add a PACKAGECONFIG for libbfd stack traces
- 3b18a9372 menulibre: upgrade 2.2.0 -> 2.2.1
- df6804c40 freeradius: fix CVE-2019-10143
- 62a4970d2 kea: fix kea-dhcp4.service/kea-dhcp6.service start up failed
- 1db745db4 networkmanager: Upgrade 1.18.2 -> 1.18.4
- 5077cd45b exiv2: initial add 0.27.1
- bf7670ff2 wvstreams,wvdial: Mark incompatible for musl

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>