### PR TITLE
Initial changes for v54

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -14,7 +14,6 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-filesystems \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-virtualization \
-  ${OEROOT}/layers/meta-selinux \
   ${OEROOT}/layers/meta-updater \
 "
 

--- a/default.xml
+++ b/default.xml
@@ -9,7 +9,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="89f70e07ef36237511964125dc3ba97294cdb50c"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="aea3771baa77e74762358ceb673d407e36637e5f"/>
   <project name="meta-intel" path="layers/meta-intel" revision="eacd8eb9f762c90cec2825736e8c4d483966c4d4"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f7edcab5d335c766adcbfc1184a843e988e59e21"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1da5deb8cb1759c117acb4980a78e86ac480cd70"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="e99bcd36e0275a093f3b12807b154105eb0a27ca"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="cee2557dc872ddaf721e6badb981c7772503f8ea"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="0d5a7c956fcc2ccd56d477ea546b272af4db4c37"/>

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,7 @@
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="cee2557dc872ddaf721e6badb981c7772503f8ea"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="0d5a7c956fcc2ccd56d477ea546b272af4db4c37"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="069a9fa127a7fefc7cf5ffaa51c9771a624eccf5"/>
-  <project name="meta-updater" path="layers/meta-updater" revision="943de02a39d021aae6337736468b03c29cb96161"/>
+  <project name="meta-updater" path="layers/meta-updater" revision="a32ce447337da7eb306e0e38effa778edd72450e"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="241405f616f22d4208d71b520821b428172e6d6b"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="edf4ab9bd70216ae0f3736fd8562938a103da3b2">
     <linkfile dest="setup-environment" src="../../.repo/manifests/setup-environment"/>

--- a/default.xml
+++ b/default.xml
@@ -8,7 +8,7 @@
   <project name="bitbake" revision="5d83d828cacb58ccb7c464e799c85fd2d2a50ccc"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="89f70e07ef36237511964125dc3ba97294cdb50c"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="aea3771baa77e74762358ceb673d407e36637e5f"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="f247a8a3b6e75b67f9de7e21fbecf7834125b174"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="eacd8eb9f762c90cec2825736e8c4d483966c4d4"/>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f7edcab5d335c766adcbfc1184a843e988e59e21"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="e99bcd36e0275a093f3b12807b154105eb0a27ca"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="cee2557dc872ddaf721e6badb981c7772503f8ea"/>

--- a/default.xml
+++ b/default.xml
@@ -14,7 +14,6 @@
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="cee2557dc872ddaf721e6badb981c7772503f8ea"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="0d5a7c956fcc2ccd56d477ea546b272af4db4c37"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="069a9fa127a7fefc7cf5ffaa51c9771a624eccf5"/>
-  <project name="meta-selinux" path="layers/meta-selinux" revision="c5b32c4d3a55274c4051c1dc9dc670620fbac5c5"/>
   <project name="meta-updater" path="layers/meta-updater" revision="943de02a39d021aae6337736468b03c29cb96161"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="241405f616f22d4208d71b520821b428172e6d6b"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="edf4ab9bd70216ae0f3736fd8562938a103da3b2">


### PR DESCRIPTION
* Latest meta-intel
* Latest meta-updater
* Latest meta-lmp

Meta-selinux was also removed as it is not strictly required by meta-virtualization anymore.