### PR TITLE
conf: imx_hab4: script to print the fuse table

### DIFF
--- a/conf/imx_hab4/print_fuses
+++ b/conf/imx_hab4/print_fuses
@@ -1,0 +1,2 @@
+#!/bin/sh
+hexdump -e '/4 "0x"' -e '/4 "%X""\n"' SRK_1_2_3_4_fuse.bin


### PR DESCRIPTION
not sure where to put this, maybe we need a place to store the CST.3.1 and add this script there?

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>