### PR TITLE
Switch meta-lmp to meta-lmp-base and meta-lmp-bsp

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -26,6 +26,7 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-rtlwifi \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
+  ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "
 
 # Add your overlay location to EXTRALAYERS
@@ -33,7 +34,7 @@ BSPLAYERS ?= " \
 EXTRALAYERS ?= ""
 
 BBLAYERS = " \
-  ${OEROOT}/layers/meta-lmp \
+  ${OEROOT}/layers/meta-lmp/meta-lmp-base \
   ${BASELAYERS} \
   ${BSPLAYERS} \
   ${EXTRALAYERS} \

--- a/default.xml
+++ b/default.xml
@@ -9,7 +9,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="0be39721cea6e04c589a419f4bb07fabd0da6704"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="aea3771baa77e74762358ceb673d407e36637e5f"/>
   <project name="meta-intel" path="layers/meta-intel" revision="abc176bde58b3339298c5ba174d7be2f86ae387d"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="895130fdf2aa0d76193ddb26815c769cdc642622"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="0c3b2340811774b495920c397c5603448446d160"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="e99bcd36e0275a093f3b12807b154105eb0a27ca"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="ed6b75ba692b5d6bafd770f6669492db9cf97e37"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="0d5a7c956fcc2ccd56d477ea546b272af4db4c37"/>


### PR DESCRIPTION
Meta-lmp is now composed of two layers, one for the base distro settings
and another for the BSP specific changes.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>