### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -9,7 +9,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="4af1824f3daa13bd2bceafe8de7f371b35e0dfce"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="aea3771baa77e74762358ceb673d407e36637e5f"/>
   <project name="meta-intel" path="layers/meta-intel" revision="b04e1edb9300a57e200a187a3255f67b50519202"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="44fcdffdc3fe7121f8447cf5945569d5bf9700d7"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c4d523b5f3faf8f8fc5f755adab95effe1a138ab"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="0d16b31c3d96e0797d3335d44545412996c48c9a"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="ed6b75ba692b5d6bafd770f6669492db9cf97e37"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="0d5a7c956fcc2ccd56d477ea546b272af4db4c37"/>


### PR DESCRIPTION
Relevant changes:
- c4d523b lmp.bbclass: allow factory specific customizations
- 889a781 bsp: lmp-machine-custom: mx8mm: extend default kernel devicetree files
- e58426b bsp: lmp-machine-custom: mx8mm: sota: add ubootenv to client features
- d8691f5 bsp: lmp-machine-custom: mx8mm: set provider for u-boot-fw-utils
- e7d83e0 bsp: u-boot-imx: split common logic and add u-boot-imx-fw-utils

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>