### PR TITLE
imx_hab4: spl template: unlock CAAM page 0

### DIFF
--- a/conf/imx_hab4/u-boot-spl-sign.csf-template
+++ b/conf/imx_hab4/u-boot-spl-sign.csf-template
@@ -15,10 +15,13 @@ File = "@@KEY_ROOT@@/CSF_1_crt.pem"
 
 [Authenticate CSF]
 
+[Unlock]
+Engine = CAAM
+Features = MID, RNG
+
 [Install Key]
 # Key slot index used to authenticate the key to be installed
 Verification index = 0
 # Key to install
 Target index = 2
 File = "@@KEY_ROOT@@/IMG_1_crt.pem"
-


### PR DESCRIPTION
the HAB locks the job ring and DECO master ID registers in a closed
configuration. Since we need OP-TEE to reconfigure those for CA7
access, unlock the CAAM configuration page and features (documented in
the Code Signing Tool user guide)

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>