### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -12,7 +12,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="2d5adaea3165ed728f0cef52528c99708ac34c0a"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="fdc6360b8f803257e9ad74a3ce150d6e2393fa8a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="2b0a523adeb5ab8b20135375dccb3cacce582fbe"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="abc914a3a8bcedf84e56b860d2931a2720d2b8d0"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="e0c22856f531efce2ca2519f22fe1e133c91508f"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="b09d0bd4d7571bb72d512c1d4d583a414bd02248"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="b422a0ae50a3960fd9cd0c6c03a40535ac4931a6"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="0cc3fb1439892c69cc1ee253b828f7e13d5569d9"/>


### PR DESCRIPTION
Relevant changes:
- e9db4a1 base: recipes-support: fioconfig: add path monitor to start service
- 30bb7f5 base: recipes-support: fioconfig: add toml helper support
- f270db1 base: linux-lmp: bump kernel to 5.4.36
- 242fc4a bsp: u-boot-ostree-src: imx6ullevk: define fit load address
- dc9173c bsp: lmp-machine-custom: imx6ullevk: define uboot dtb/rd loadaddr
- 3e39cb3 bsp: machine: cubox-i enable boot.itb support and sync settings
- bc7d915 bsp: u-boot-fio: update cubox-i fitimage support patch
- b744067 bsp: u-boot: move cubox-i to u-boot-fio
- 55c28ca revert: remove cubox-i support (Hummingboard2)
- 10a293a base: u-boot-fio: bump revision
- 126d59c bsp: lmp-machine-custom: imx6ullevk: set WKS_FILE
- aebaead bsp: lmp-machine-custom: add support for imx6ullevk
- 8f263ea bsp: u-boot-fio: add config fragment for imx6ullevk
- 20448f2 bsp: u-boot-ostree-scr: add support for imx6ullevk
- d4bd110 base: recipes-sota: aktualizr: move to master branch
- 3ae1b3d base: linux-lmp: bump kernel to 5.4.35
- b75511d base: linux-lmp: meta: add bsp definition for imx6ullevk
- 2e64521 base: linux-lmp: bump kernel to 5.4.33

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>