### PR TITLE
scripts: change the way to get the current branchd

### DIFF
--- a/scripts/update-factory-manifest
+++ b/scripts/update-factory-manifest
@@ -29,7 +29,7 @@ abort_merge()
 }
 
 # get current branch
-local_branch=$(git branch --show-current)
+local_branch=$(git rev-parse --abbrev-ref HEAD)
 
 # look for a remote tracking branch
 remote_branch=$(git config --get branch.${local_branch}.merge || true)


### PR DESCRIPTION
Use 'rev-parse --abbrev-ref' instead of 'branch --show-current' as it
less demanding to a git version (2.22 is required for the later).

Signed-off-by: Mike Sul <mike.sul@foundries.io>