### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -12,7 +12,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="6bc3d8825c20d21528e24a7237ff7392e01a81bd"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="c15c74ad1c973724e6b83b2c1ad862c7caf9ed32"/>
   <project name="meta-intel" path="layers/meta-intel" revision="31840bc6cf6e1d86ef911ea214da2169a3c885ca"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="dac2153867b3c698012cb4c5c8f4b908f28266c0"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1ea1d10c08b2ffcfda1cc8e66224c8d2c44dd679"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="76b83194b31ca57790fdffb43c81c8cb0131f527"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="fc72c061411ea78515a670b63b0d44c13451cb78"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="4354bf2888149a3641ef2eeb05a73918616e154b"/>


### PR DESCRIPTION
Relevant changes:
- 1ea1d10 base: softhsm: add release 2.6.1
- ab79ee5 base: linux-lmp: bump kernel to 5.4.54
- e8328f2 base: optee-os: bump to a04118ba
- c308ff1 base: kernel-lmp-fitimage: add support for FIT_LOADABLES
- 42ccce1 base: optee-sks: bump to e098eeb7
- 3f5499d base: optee-os: bump to 0c997974

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>