### PR TITLE
Add support for meta-arm/meta-arm-bsp

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -14,6 +14,8 @@ BASELAYERS ?= " \
   ${OEROOT}/layers/meta-openembedded/meta-filesystems \
   ${OEROOT}/layers/meta-openembedded/meta-perl \
   ${OEROOT}/layers/meta-openembedded/meta-python \
+  ${OEROOT}/layers/meta-arm/meta-arm \
+  ${OEROOT}/layers/meta-arm/meta-arm-toolchain \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-updater \
   ${OEROOT}/layers/meta-security \
@@ -28,8 +30,13 @@ BSPLAYERS ?= " \
   ${OEROOT}/layers/meta-rtlwifi \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
+  ${OEROOT}/layers/meta-arm/meta-arm-bsp \
   ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "
+
+# Remove layer dependencies that are not used/required by LMP
+## LMP provides its own kernel recipes
+LAYERDEPENDS_meta-arm-bsp_remove = "meta-kernel"
 
 # Add your overlay location to EXTRALAYERS
 # Make sure to have a conf/layers.conf in there

--- a/default.xml
+++ b/default.xml
@@ -9,6 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
+  <project name="meta-arm" path="layers/meta-arm" revision="8ddfd20f79124678cab501a80e159c10cfd5f41f"/>
   <project name="meta-freescale" path="layers/meta-freescale" remote="fio" revision="9de9ef9a82da7b9dcfa1a85c949477677dba2794"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="c15c74ad1c973724e6b83b2c1ad862c7caf9ed32"/>
   <project name="meta-intel" path="layers/meta-intel" revision="9e9b9fd332ab259db05578b0ae36b28a2fd8bd92"/>

--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" remote="fio" revision="9de9ef9a82da7b9dcfa1a85c949477677dba2794"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="c15c74ad1c973724e6b83b2c1ad862c7caf9ed32"/>
   <project name="meta-intel" path="layers/meta-intel" revision="9e9b9fd332ab259db05578b0ae36b28a2fd8bd92"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1401980609853096b8c1f858a666a13d029aca92"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9acd786b4260cb64f057c1b77e2a0f1c96f2501d"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="25871c20688fdbca0bc773adad2d6b782d9ef719"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="64bd47fe588e1684b1ec49fa01d1e1176d93d697"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="e7c5476aedabe3a99a534e920ec6fd278ab06637"/>


### PR DESCRIPTION
Layer used to provide generic ARM related components such as ATF and OP-TEE, besides BSP support for ARM specific targets such as corstone and a5ds.