### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" remote="fio" revision="9de9ef9a82da7b9dcfa1a85c949477677dba2794"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="c15c74ad1c973724e6b83b2c1ad862c7caf9ed32"/>
   <project name="meta-intel" path="layers/meta-intel" revision="9e9b9fd332ab259db05578b0ae36b28a2fd8bd92"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="ad0dede4540846769a89fd264ab430db0024614a"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="db2e42069362ec8d27172b2d144145a85eba3c3a"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="25871c20688fdbca0bc773adad2d6b782d9ef719"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="64bd47fe588e1684b1ec49fa01d1e1176d93d697"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="e7c5476aedabe3a99a534e920ec6fd278ab06637"/>


### PR DESCRIPTION
Relevant changes:
- db2e420 base: optee-os-fio: bump rev to e20d5441
- be6db7f bsp: linux-lmp-fslc-imx: fix optee i2c communication
- c9b6d28 bsp: linux-lmp-toradex-imx: bump rev to 27e8bf72449fb
- 89b5edb bsp: linux-lmp-fslc-imx: update to v5.4.65
- 4729128 base: linux-lmp-lts: update to v5.4.65
- 51b8192 base: linux-lmp: update to v5.8.9

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>