### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="350017397b22930c854a8024a0d7b825f000de26"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
   <project name="meta-intel" path="layers/meta-intel" revision="a064295cd5e40f83e86378f86dd42d7f783a6eea"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="b88eb75f1b02bbae170ee6eadfc7fa30bb4a4119"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4461fc3e23718c54f5461c0d2f96686c336fd147"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="7e60006ecc3d9f8cca6c2394a79b14e54aedf474"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="2324089fef0e5e23c4a74bceb7a99b3bab8f73be"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="d9b156970327c405ee380baf20af01a53b334401"/>


### PR DESCRIPTION
Relevant changes:
- 4461fc3 base: optee-sks: bump to 20defe5e
- 79b3bfa base: pkcs11-se050-import: add recipe
- c7899a7 base: optee-os-fio: 3.10: bump to ba1333a53
- e819d70 bsp: u-boot-fio: apalis-imx8: add lmp-base fragment
- b56c7af bsp: u-boot-base-scr: apalis-imx8: fix boot logic based on latest u-boot
- c76c996 bsp: lmp-machine-custom: apalis-imx8: update image boot files for lmp-base
- 74fb59d bsp: lmp-machine-custom: mx8mm: update image boot files for lmp-base
- 1042d65 bsp: u-boot-fio: imx8mmevk: add lmp-base fragment
- 3d9717b bsp: u-boot-base-scr: imx8mmevk: fix boot logic based on latest u-boot
- 5a8f824 bsp: lmp-mfgtool-machine-custom: explicitly enable uboot sign
- 0b23e6b bsp: lmp-machine-custom: only enable uboot sign with sota
- e73c6f1 fioconfig: Bump to version with updated help text

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>