### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="350017397b22930c854a8024a0d7b825f000de26"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
   <project name="meta-intel" path="layers/meta-intel" revision="a064295cd5e40f83e86378f86dd42d7f783a6eea"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4461fc3e23718c54f5461c0d2f96686c336fd147"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="dce6515ffecf604be234eec8c84c2e781e96df70"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="7e60006ecc3d9f8cca6c2394a79b14e54aedf474"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="2324089fef0e5e23c4a74bceb7a99b3bab8f73be"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="d9b156970327c405ee380baf20af01a53b334401"/>


### PR DESCRIPTION
Relevant changes:
- 3507fc9 bsp: lmp-machine-custom: apalis-imx6: fix lmp-base support
- dd3906e bsp: u-boot-base-scr: apalis-imx6: fix boot logic
- 65cf654 bsp: wic: add sdimage-imx6dq-spl-fit.wks
- 6f183ac bsp: u-boot-fio: apalis-imx6: add lmp-base.cfg
- d40b7e4 bsp: u-boot-base-scr: apalis-imx6: fix bootcmd
- 1c333b5 bsp: u-boot-ostree-scr: drop support for apalis-imx6
- f872a6b base: u-boot-fio-mfgtool: add standard and empty lmp.cfg fragment

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>