### PR TITLE
default.xml: update meta-lmp layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -13,7 +13,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="3ca9a41ee610bceb5f4d3025a2a4c799b8576db4"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="b85d08a55cb833bfc4e8b5034ff804286c67620e"/>
   <project name="meta-intel" path="layers/meta-intel" revision="8089e92d77bc11051463580eb0b0687e768bc8d2"/>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="8271635a7e8c770fe238458201b5ac0e420f1257"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="cc58a549a709d52f096a98cb6cd5c857834e4ba0"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="ac4ccd2fbbb599d75ca4051911fcbaca39dbe6d7"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="09a3c11696c75593f8e475da5dfb401016c6aaca"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="9a75ffbb21ebee61782576d524a454d04a9f91e2"/>


### PR DESCRIPTION
Relevant changes:
- cc58a54 base: images: require lmp-feature-factory.inc
- 44ad5e6 base: lmp-device-register: add generic factory specific configs
- dd8b3ab base: lmp-device-register: bump to b59e76abb3
- 18d8430 docker-credential-helper: Support variable server names
- 5f82683 base: initramfs-module-install-efi: support preloaded containers
- 673ab49 base: initramfs-module-install-efi: loop with find instead of readlink
- 5a85340 base: initramfs-module-install-efi: support lmp customizations
- fd18665 base: initramfs-module-install-efi: set boot partition to 100mb
- c7c59b6 base: image-efi-installer.wks: increase boot partition to 100mb
- f5bd8cd base/bsp: drop zeus and dunfell from compat
- 169d9a8 recipes-support: mfgtool-files: allow full_image flash filename override
- c58fa1c base: aktualizr-lite: bump to 62142af

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>