### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="431274d9f4b8e9b77a91ddf76365906a57428004"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f92f90139a247b8bf0e945a9449eda1d409f65c9"/>
   <project name="meta-clang" path="layers/meta-clang" revision="f1adebb07e2de0d7949f8347560feabd10d19846"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="ac4ccd2fbbb599d75ca4051911fcbaca39dbe6d7"/>
   <project name="meta-security" path="layers/meta-security" revision="e8c9e69c80ea2c525250e07db1024d8e34f1f0f8"/>


### PR DESCRIPTION
Relevant changes:
- f92f901 base: mfgtool-files: fix file names and md5/sha256sum
- 2b20a1c u-boot-fitImage: pass the machine name in the SPL fit
- 954e88a bsp: u-boot-ostree-scr: drop support for qemuriscv64
- ea72a20 bsp: u-boot-ostree-scr: drop support for imx8mmevk
- a25b3b1 bsp: u-boot-ostree-scr: drop support for apalis-imx8
- 7e2125f bsp: u-boot-ostree-scr-fit: imx6ullevk: fix fdtfile typo
- f705f15 bsp: lmp-mfgtool-machine-custom: fix UBOOT_SIGN_ENABLE for mx8mq

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>