### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="99191382fb3e4fa40db0b841d97c0cf0d5c0574c"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7f92e5a75558cd817fd20a275f627b4e3a769ce5"/>
   <project name="meta-clang" path="layers/meta-clang" revision="04a1194c78563524659f27941304e564956792b1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="cef93b7b00e620d90a610112ee574fa60b691cf8"/>
   <project name="meta-security" path="layers/meta-security" revision="4583ab9b08c1c582a9d7e8ab70d6685ed4720799"/>


### PR DESCRIPTION
Relevant changes:
- 7f92e5a base: optee-os-fio: 3.10: bump to 915ee978d
- 3b3442f bsp: lmp-machine-custom: mx8mm: fix lmp-base settings
- fea32d7 bsp: u-boot-fio: lmp-base: add SPL_DM support
- 9919ac2 bsp: imx-mkimage: mx8mm: guard deploy steps with IMXBOOT_TARGETS check

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>