### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7ac388d102b943852de46d249ef77b6aa5ae51ac"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1aafcbb400522a1f3f2f7ca5bfaa74d7272e6fc7"/>
   <project name="meta-clang" path="layers/meta-clang" revision="04a1194c78563524659f27941304e564956792b1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="945f062ff098dc9c8ba8d22c5eef88adec60730d"/>
   <project name="meta-security" path="layers/meta-security" revision="adcd7c43717274e6274a98133db5c2a4314dac97"/>


### PR DESCRIPTION
Relevant changes:
- 1aafcbb base: collectd: add default configuration for lmp
- 04367f4 base: rrdtool: disable rrd_graph and fix perl install
- 23c9fc7 base: optee-os-fio: 3.6: bump to c67d7defe31
- a90fcd3 base: u-boot-fio: 2020.04: bump to f5ef084e7cb

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>