### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="b70cd394819915752d3ce7c066dafff75d9126cd"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f44f301711bc90fc6bbc4697046f649a934692d3"/>
   <project name="meta-clang" path="layers/meta-clang" revision="04a1194c78563524659f27941304e564956792b1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="945f062ff098dc9c8ba8d22c5eef88adec60730d"/>
   <project name="meta-security" path="layers/meta-security" revision="adcd7c43717274e6274a98133db5c2a4314dac97"/>


### PR DESCRIPTION
f44f301 base: u-boot-fio: 2020.04: bump to c8e17fe087
3d0816b bsp: mfgtool-files: imx8mmevk: add flashing of secondary boot images
73ae186 imx-boot: add SIT image build
fb13646 u-boot-fio: imx8mmevk: add support for secondary boot images
623208c base: u-boot: set u-boot localversion string
fed052c base: add fio-u-boot-localversion.bbclass
28237f4 optee: add configuration for 3.12

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>