### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4697b6194ac56cab2c124b0ccff33b22229ea664"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="89b307c60712f605193dee8cdea94ad9f6833ca2"/>
   <project name="meta-clang" path="layers/meta-clang" revision="04a1194c78563524659f27941304e564956792b1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="945f062ff098dc9c8ba8d22c5eef88adec60730d"/>
   <project name="meta-security" path="layers/meta-security" revision="adcd7c43717274e6274a98133db5c2a4314dac97"/>


### PR DESCRIPTION
Relevant changes:
- 38f1da5 base: meta-linux-lmp-5.4.y: bump to 71b6bbf2
- 570695e bsp: conf: lmp-machine-custom: add support for ti am64xx-sk platform
- 4bb2c4e bsp: recipes-bsp: u-boot-ostree-scr: add support for am64xx-sk
- c66e680 bsp: recipes-bsp: uboot-ti-staging: enlarge the bootm memory size
- 45781af bsp: recipes-kernel: add linux-lmp-ti-staging recipe to support am64xx-sk

Additional changes:
- 89b307c base: optee-fiovb: bump to 2fb0daf
- 9a6f394 base: lmp-device-register: bump to bc56368f
- 42dc3ee bsp: mfgtool-files: imx8mqevk: erase boot partition prior to flashing
- e20ce83 bsp: mfgtool-files: imx8mmevk: erase boot partition prior to flashing
- f1bf2d2 bsp: mfgtool-files: imx6ullevk: erase boot partition prior to flashing
- 0474409 bsp: mfgtool-files: apalis-imx8: erase boot partition prior to flashing
- 6348162 bsp: mfgtool-files: apalis-imx6: erase boot partition prior to flashing
- 142fcf6 base: aktualizr-lite: bump to 9010446

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>