### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="6f40b3f448589dae2b49476f52e736327074ad6c"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="66e42f4db26272c83ac9b407f383505209c40ac3"/>
   <project name="meta-clang" path="layers/meta-clang" revision="04a1194c78563524659f27941304e564956792b1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="945f062ff098dc9c8ba8d22c5eef88adec60730d"/>
   <project name="meta-security" path="layers/meta-security" revision="3daf99fd138b0eebe864bbe1b9c71241d97c4512"/>


### PR DESCRIPTION
Relevant changes:
- 46f9768 bsp: recipes-support: mfgtool-files: imx6ullevk: use std load method
- 14130f9 bsp: recipes-bsp: u-boot-fio-mfgtool: imx6ullevk: update config
- 6c7f2f3 bsp: recipes-bsp: u-boot-fio: imx6ullevk: update config
- 84db852 base: u-boot-fio: 2020.04: bump to a36d90e2
- 1eb65c4 base: optee-os-fio: 3.10: bump to 12c10709
- 92018bc bsp: u-boot-fio: freedom-u540: use fw_dynamic from sysroot
- a84df42 bsp: opensbi: export fw_payloads to sysroot
- f4f2b7d bsp: optee-os-fio-mfgtool: 3.10.0: apalis-imx6: enable CFG_CORE_DYN_SHM
- 2784815 base: dropbear: prefer ecdsa instead of rsa
- 53c2e5f bsp: lmp-machine-custom: update settings for freedom-u540
- 10c2524 bsp: opensbi: support fw_dynamic u-boot fit-image for freedom-u540
- 546ecb1 bsp: base-files: add fstab for freedom-u540
- c029610 bsp: wic: add SiFive 4 partition wic layout for lmp-base
- 21f2012 bsp: wic: add SiFive 4 partition wic layout for sota
- fd147bf bsp: u-boot-ostree-scr: drop support for freedom-u540
- 2f4c3f7 bsp: u-boot-base-scr: add support for freedom-u540
- 47ce4f4 bsp: u-boot-ostree-scr-fit: add support for freedom-u540
- f358fd7 bsp: u-boot-fio: add lmp-base support for freedom-u540
- 4486047 bsp: u-boot-fio: add lmp feature support for freedom-u540
- 20e1e88 bsp: lmp-machine-custom: qemuarm64: switch to optee 3.12.0
- b475907 bsp: lmp-machine-custom: freedom-u540: use kernel-lmp-fitimage
- d148903 bsp: lmp-machine-custom: rpi drop u-boot-fio preferred version
- 9217c14 base: u-boot-fio: 2021.04: make it default
- f4bc271 base: kmeta-linux-lmp-5.10.y: bump to 6cd85741
- 7e01adb base: optee-os-fio: 3.10: bump to dafb267d
- b9cfbc0 base: u-boot-fio: 2020.04: bump to 7312631761
- d4986f5 u-boot-fio: imx8mmevk: enable secondary boot aux cmds by default
- 513b050 bsp: imx-atf: add secondary_boot SiP calls
- 09dc49d base: networkmanager: make bbappend specific to the 1.22 series
- 8509ab8 base: classes: allow 64-bit addresses in fit image
- e73029c bsp: imx8mmevk: pre-load boot script from u-boot FIT image
- 572c1e0 uboot-fitimage: include boot script in u-boot.itb

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>