### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="482182a145b7018b10e3af56d05a2920ead6e00b"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="cbd4e299d9fc86246e05986e9c490351562caaec"/>
   <project name="meta-clang" path="layers/meta-clang" revision="04a1194c78563524659f27941304e564956792b1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="945f062ff098dc9c8ba8d22c5eef88adec60730d"/>
   <project name="meta-security" path="layers/meta-security" revision="3daf99fd138b0eebe864bbe1b9c71241d97c4512"/>


### PR DESCRIPTION
Relevant changes:
- cbd4e29 base: aktualizr-lite: move tmpdir to /run
- a9e40d9 bsp: mfgtool-files: apalis-imx6: write secondary boot images
- 9b27273 u-boot-fio: apalis-imx6: lmp-base: secondary boot support
- 6d434f5 u-boot-fio: apalis-imx6: add secondary boot image defines
- 9f797d3 u-boot-fio-mfgtool: apalis-imx6: add secondary boot support defines
- 564f4e3 bsp: mfgtool-files: imx6ullevk: write secondary boot images
- e0df2eb bsp: recipes-bsp: u-boot-fio: imx6ullevk: PSCI reset and watchdog
- 7214732 u-boot-fio-mfgtool: imx6ullevk: add secondary boot defines for fsb
- 72b35fe u-boot-fio: imx6ullevk: add secondary boot image defines
- a0d559a bsp: imx-boot: drop SIT image generation
- f1de650 bsp: u-boot-fio-common: add support for sit generation
- 3ee3b5d base: u-boot-fio: bump to 4b11d263c2
- d9bade7 bsp: ultrazed-lmp: add support for lmp-base
- 50b9fb8 bsp: u-boot-xlnx: add support for lmp-base.cfg
- 97e8429 bsp: u-boot-base-scr: add support for uz3eg-iocc

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>