### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -2,6 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/foundriesio" name="fio"/>
   <remote fetch="https://source.foundries.io/lmp-mirrors" name="lmp-mirrors"/>
+  <remote fetch="https://github.com/munoz0raul" name="munoz0raul"/>
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
@@ -9,7 +10,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f838fe62de6da3bc3583613d1a3659e219ff6f72"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="munoz0raul" revision="844fb271ee3519d2b7482e9aad6eceb116e5027f"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="85f8047c71047d93cf79a954142157f85079968d"/>
   <project name="meta-security" path="layers/meta-security" revision="6466c6fb02f36f459b06d434484df26e083f3489"/>
   <project name="meta-updater" path="layers/meta-updater" revision="5d49b28570ed030924ed5d45fbced24d3cb6e588"/>


### PR DESCRIPTION
Relevant changes:
- 2ab80139 base: ostreeuploader: bump to 54daa67
- e2ea1aa6 base: aktualizr: create tmpfiles for /var/sota
- bd62e958 base: ostreeuploader: bump to 1b11a24
- 5346e08d recipes-sota: Bump aklite version
- c6d50a12 base: aktualizr-lite: bump to 4999fa0
- 7b7cc2db base: aktualizr: package get and lite separately
- 5441b9d4 base: aktualizr: return to build dir to fix configure
- fde61b27 base: lmp.inc: add seccomp to distro features
- f5734d41 lmp.conf: drop usrmerge as it is already set in lmp.inc
- 24025371 base: lmp-mfgtool: use reproducible_build instead of simple
- d47ada6e base: lmp.conf: drop sota.conf.inc require
- c80e8435 base: lmp-mfgtool: mask meta-integrity kernel append
- c995e50b base: Remove prebuilt image logic
- b7456cdf base: aktualizr-lite: bump to df0760a
- 7a38dc9d base: aktualizr-lite: bump to ab345cc
- 5ecf1029 base: aktualizr-lite: drop the update lock usage
- 02e9993d base: aktualizr-lite: bump to 1affb7e
- ab118dc9 base: lmp: mask systemd append from meta-integrity
- 2552e559 base: aktualizr-lite: bump to 410bcdf
- cd1992e6 base: aktualizr-lite: bump to e7821f4
- a8d0cace base: class: lmp-disable-gplv3: Enable the LMP_DISABLE_GPLV3
- bbc2a229 uboot-fitimage: provide dump ATF address if ATF is not used
- 4b05af57 base: fiotools: switch to the ostreeuploader git repo
- 92f28b3a base: aktualizr-lite: bump to 5a0b9d5
- b2a7d431 base: aktualizr-lite: move tmpdir to /run
- 6b0dae49 base: fiotools: use fiotools instead garage-tools
- 8cb3624b base: fiotools: add a recipe for fiotools
- bd2b442d base: classes: allow 64-bit addresses in fit image
- 501acad1 uboot-fitimage: include boot script in u-boot.itb
- 39d039dd u-boot-fitImage: pass the machine name in the SPL fit
- 5935037d base: preload: remove useless 'arch' param
- 11168583 base: recipes-support: libfyaml
- 70b5bfe5 base: classes: kernel-fit-image: fix DTB iteration variable
- b8ce9f63 base: lmp: ostree: update default home path
- f6767624 base: lmp: add lmp-disable-gplv3 bbclass
- fca78e0a base: lmp: ostree: add lmp specific cleanups
- 909a5109 base: u-boot-fitimage: fix support for atf
- 2e7b12c6 base: u-boot-fitimage: add support ATF as payload
- 893139f9 base: classes: uboot-fitimage: better handling for SPL_BINARY

Signed-off-by: Raul Muñoz <raul@foundries.io>