### PR TITLE
bblayers.conf: if exists include bblayers-partner.inc

### DIFF
--- a/conf/bblayers.conf
+++ b/conf/bblayers.conf
@@ -10,6 +10,7 @@ BBFILES = ""
 require bblayers-base.inc
 require bblayers-bsp.inc
 
+include bblayers-partner.inc
 include bblayers-factory.inc
 
 BBLAYERS = " \

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -212,6 +212,9 @@ ln -sf "${MANIFESTS}"/conf/bblayers-bsp.inc conf/bblayers-bsp.inc
 if [ -f "${MANIFESTS}"/conf/bblayers-factory.inc ]; then
     ln -sf "${MANIFESTS}"/conf/bblayers-factory.inc conf/bblayers-factory.inc
 fi
+if [ -f "${MANIFESTS}"/conf/bblayers-partner.inc ]; then
+    ln -sf "${MANIFESTS}"/conf/bblayers-partner.inc conf/bblayers-partner.inc
+fi
 ln -sf "${MANIFESTS}"/README.md README.md
 
 ln -sf "${MANIFESTS}" "${OEROOT}"/layers/


### PR DESCRIPTION
Add support for a partner Factory bblayers include file which
won't conflict with the standard LmP manifest.

Signed-off-by: Michael Scott <mike@foundries.io>