### PR TITLE
lmp-bsp: update meta-freescale layer

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -5,7 +5,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="ba82ea920a3a43244a0a72bd74817e2f00f4a1af"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="31a9d22895598a77e8320ca77787a81c81294697"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="31a9d22895598a77e8320ca77787a81c81294697"/
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="bcfa0798fe44452b1834b298b0ca8147c2469e43"/>
   <project name="meta-intel" path="layers/meta-intel" revision="5c4a6b02f650a99a5ec55561443fcf880a863d19"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="9d372828ba657340a42e31875d2326e5f6753403"/>


### PR DESCRIPTION
Relevant changes:
- 469d6c95 ("Merge pull request #880 from Freescale/backport-879-to-hardknott")
- fc46bcc0 ("imx6ullevk: remove obsolete device tree entry")

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>