### PR TITLE
lmp-bsp: update meta-freescale layer

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -5,7 +5,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="ba82ea920a3a43244a0a72bd74817e2f00f4a1af"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="25e9cbddbd32802634bafef62ba08da9821c604d"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="3158e7f2b505074dec80307ad3db7e9d51b08fab"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="bcfa0798fe44452b1834b298b0ca8147c2469e43"/>
   <project name="meta-intel" path="layers/meta-intel" revision="5c4a6b02f650a99a5ec55561443fcf880a863d19"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="9d372828ba657340a42e31875d2326e5f6753403"/>


### PR DESCRIPTION
This bump fixes building imx-atf (NXP changed the branch plan).

Relevant changes:
  - 3158e7f2 Merge pull request #925 from migronof/dtb-fix
  - bd8d3e1a imx8qm-mek: remove obsolete dtb
  - 31a9d228 Merge pull request #897 from MrCry0/hardknott-fixes
  - fc46bcc0 imx6ullevk: remove obsolete device tree entry
  - 469d6c95 Merge pull request #880 from Freescale/backport-879-to-hardknott
  - 7a0d46d8 kernel-module-imx-gpu-viv: use source code from 5.10.52
  - c0659168 linux-imx*: Upgrade to 5.10.52
  - 87931f3d Merge pull request #877 from Freescale/backport-876-to-hardknott
  - a578a8bb conf: machine: imx8mp-lpddr4-evk: align dtbs with new kernel
  - eaa21ad3 linux-fslc-imx: upgrade to lf-5.10.52-2.1.0 from NXP
  - 02430d3f Merge pull request #875 from angolini/hardknott-linux-fslc-imx
  - 28b3ca70 linux-fslc-imx: update to v5.4.147
  - 389b40d8 linux-fslc-imx: update to v5.4.145
  - e75335b7 linux-fslc-imx: update to v5.4.144
  - 71133540 linux-fslc-imx: update to v5.4.143
  - da8cc01e linux-fslc-imx: update to v5.4.142
  - 8ec457e5 linux-fslc-imx: update to v5.4.141
  - 2b9a987a Merge pull request #869 from thochstein/hardknott
  - 231517af isp-imx: start_isp.sh: fix NR_DEVICE_TREE_BASLER variable
  - 012e0f75 Merge pull request #863 from angolini/fix-hardknott+bsp
  - f06c7da5 jailhouse: Drop from MACHINE_FEATURES_BACKFILL
  - 866feecf tinycompress: Fix build with musl
  - d450c86a imx-base: Fix characteres included on backport by mistake
  - 16e0d07d Merge pull request #859 from angolini/hardknott+bsp
  - b821d72e qcacld: Drop BSP support
  - 758ef644 imx8mm-evk.inc: Drop qca9377
  - 250ff338 xorg-xserver: Remove a patch already applied upstream
  - 00e5785e imx8mq-evk.conf: Drop redundant gstreamer preferred version
  - cf6087f8 imx-base.inc: Set gstreamer preferred version to 1.18.0[.imx]
  - 2a9919d2 tinycompress: Add recipe
  - 6b19e216 imx-gst1.0-plugin: Upgrade to 4.6.1
  - c2deae4b gstreamer1.0-rtsp-server: Upgrade to 1.18.0
  - edbf1650 gstreamer1.0-libav: Upgrade to 1.18.0
  - eb570db8 gstreamer1.0-plugins-ugly: Upgrade to 1.18.0
  - c344e56a gstreamer1.0-plugins-bad: Upgrade to 1.18.0.imx
  - c0ddccd2 gstreamer1.0-plugins-good: Drop non-functional overrides
  - 1ec8cda7 gstreamer1.0-plugins-good: Upgrade to 1.18.0.imx
  - 992328e9 gstreamer1.0-plugins-base: Align bbappend with 1.18.%
  - dccaf6b6 gstreamer1.0-plugins-base: Upgrade to 1.18.0.imx
  - 8accfe48 gstreamer1.0: Upgrade to 1.18.0.imx
  - 26d93b9b alsa-lib: Fix fuzz
  - 86139123 xserver-xorg: Backport pixmap fixes for GLES
  - 2bbde32c imx-gpu-viv: Drop empty Wayland packages
  - 308d3563 imx-gpu-viv: Move CL/cl_viv_vx_ext.h to main package
  - d0d250f9 imx-gpu-viv: Inhibit sysroot stripping
  - 412e6d27 imx-gpu-viv: Cleanup FILES_libnn-imx*
  - 7d366e17 imx-dpu-g2d: Upgrade to 1.9.2
  - aa77bc74 kernel-module-imx-gpu-viv: Upgrade to 6.4.3.p2.0
  - 1d6ba815 imx-gpu-g2d: Upgrade to 6.4.3.p2.0
  - f56ae77c imx-gpu-viv: Upgrade to 6.4.3.p2.0
  - 0d30d5e8 alsa-lib: Fix imx-cs42888 model name, fix fuzz
  - 19785f65 imx8mp-evk.inc: Make jailhouse specific to NXP BSP
  - 5055d2e8 kernel-module-isp-vvcam: Upgrade to 4.2.2.13.0
  - 4024e7c1 basler-camera: Upgrade to 4.2.2.13.0
  - d9160df6 isp-imx: Upgrade to 4.2.2.13.0
  - 0e06a2f5 imx-vpu-hantro-daemon: Add Hantro V4L2 daemon
  - 123b1d5a imx-vpu-hantro-vc: Upgrade to 1.4.0
  - 1c20118e imx-vpu-hantro: Upgrade to 1.22.0
  - d28044c1 imx-test: Upgrade to NXP release 5.10.35-2.0.0
  - d66dba5f imx-seco-libs: Upgrade to NXP release 5.10.35-2.0.0
  - c73d7211 imx-seco: Upgrade to 3.8.1
  - 37e27d39 imx-sc-firmware: Upgrade to 1.9.0
  - 20d4f73e imx-mkimage: Drop dcd files from deploy folder
  - 6f37177c imx-mkimage: Upgrade to 5.10.35-2.0.0 release
  - dd67c9c6 firmware-imx: Upgrade to 8.12
  - a004c265 u-boot-mfgtool.inc: Align SPL_IMAGE and SPL_SYMLINK with OE
  - 88062eb4 u-boot-imx: Fix deploy bug for multiple UBOOT_CONFIG entries
  - cb567e62 u-boot-imx: Fix comment
  - 087c67ae tsntool: update to 3111f7f
  - 9de18351 u-boot-imx: upgrade to 2021.04
  - 381cf20e u-boot-imx: align naming of u-boot-imx-common with u-boot-fslc
  - 0d7046d7 imx-atf: Remove -O2 from CFLAGS for 8MQ
  - 28a3b754 imx-atf: Upgrade to NXP release 5.10.35-2.0.0
  - 72ece6cd linux-imx*: Upgrade to 5.10.35
  - bb8ea8af Update EULA and SCR for NXP release 5.10.35-2.0.0
  - 25e9cbdd Merge pull request #849 from thochstein/hardknott
  - c48e0d85 imx-gpu-viv: Provides virtual/libgl for framebuffer

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>