### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="880203717a0d23b12a58a746aaa2691b7092eea2"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f7d2988400245d69bf40a237d3e57b5be388177b"/>
   <project name="meta-clang" path="layers/meta-clang" revision="b0d805060791006d651efd3d7ae3dd5add8f70fe"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="0b0ab6a2d227f22374268d29fcb8e4f9dab5374b"/>
   <project name="meta-rust" path="layers/meta-rust" revision="1b59fd45906082c978d0a0a6e4e51a0ea4aa32c7"/>


### PR DESCRIPTION
Relevant changes:
- f7d29884 base: u-boot-fio: 2020.04: bump to 67344f3a
- 818e1acb base: kmeta-linux-lmp-5.4.y: bump to 04363463
- a4247de4 bsp: optee-os-fio: imx6ulevk: drop RNG_PTA for now
- 969676ef bsp: lmp-mfgtool-machine-custom: add support for imx6ulevk
- 1ff18f5b bsp: lmp-machine-custom: add support for imx6ulevk
- c3297533 bsp: mfgtool-files: add initial support for imx6ulevk
- ebc5d8dd bsp: linux-lmp-dev-mfgtool: add defconfig for imx6ulevk
- 1e7ee126 bsp: base-files: imx6ulevk: add fstab
- 258ddc0d bsp: optee-os-fio-mfgtool: add support for imx6ulevk
- 40685c50 bsp: optee-os-fio: add support for imx6ulevk
- 5c76e84c bsp: u-boot-fio-mfgtool: add support for imx6ulevk
- e287ca3d bsp: u-boot-fio: add support for imx6ulevk
- 3b8f7a59 bsp: u-boot-ostree-scr-fit: add support for imx6ulevk
- 7aaccd29 bsp: u-boot-base-scr: add support for imx6ulevk
- 5f242402 base: aktualizr-lite: bump to d132ef7

Signed-off-by: Michael Scott <mike@foundries.io>