### PR TITLE
Hardknott stable updates

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f7d2988400245d69bf40a237d3e57b5be388177b"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f200b354a4cde5714a0a8d0299da1a7d064d762f"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2207df98559afc19d6a0243027bbac18980fc764"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="f859d299e655d92e1183ccc24a4f96c122a4ac41"/>
   <project name="meta-rust" path="layers/meta-rust" revision="1b59fd45906082c978d0a0a6e4e51a0ea4aa32c7"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -16,5 +16,5 @@
   <project name="meta-security" path="layers/meta-security" revision="c40e1e84da9624b9096a463dbed3b301c01c268e"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="3713277e2e52e35e5e24cf8b2b2003bedf33ffcf"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="cc6a2b384bef6f088254c75c8d0a7b154d2b62b7"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="e95ccf6f7fe5a42fffcfa5e43087ff964622e26c"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="f6791df317e66b2d3fa88d3a038d888d4512305a"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -10,7 +10,7 @@
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f7d2988400245d69bf40a237d3e57b5be388177b"/>
-  <project name="meta-clang" path="layers/meta-clang" revision="b0d805060791006d651efd3d7ae3dd5add8f70fe"/>
+  <project name="meta-clang" path="layers/meta-clang" revision="2207df98559afc19d6a0243027bbac18980fc764"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="0b0ab6a2d227f22374268d29fcb8e4f9dab5374b"/>
   <project name="meta-rust" path="layers/meta-rust" revision="1b59fd45906082c978d0a0a6e4e51a0ea4aa32c7"/>
   <project name="meta-security" path="layers/meta-security" revision="16c68aae0fdfc20c7ce5cf4da0a9fff8bdd75769"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,6 +15,6 @@
   <project name="meta-rust" path="layers/meta-rust" revision="1b59fd45906082c978d0a0a6e4e51a0ea4aa32c7"/>
   <project name="meta-security" path="layers/meta-security" revision="c40e1e84da9624b9096a463dbed3b301c01c268e"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="3713277e2e52e35e5e24cf8b2b2003bedf33ffcf"/>
-  <project name="meta-virtualization" path="layers/meta-virtualization" revision="be2c9d6efe545ec6718902be9c56a698662ff055"/>
+  <project name="meta-virtualization" path="layers/meta-virtualization" revision="cc6a2b384bef6f088254c75c8d0a7b154d2b62b7"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="e95ccf6f7fe5a42fffcfa5e43087ff964622e26c"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f7d2988400245d69bf40a237d3e57b5be388177b"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2207df98559afc19d6a0243027bbac18980fc764"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="0b0ab6a2d227f22374268d29fcb8e4f9dab5374b"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="f859d299e655d92e1183ccc24a4f96c122a4ac41"/>
   <project name="meta-rust" path="layers/meta-rust" revision="1b59fd45906082c978d0a0a6e4e51a0ea4aa32c7"/>
   <project name="meta-security" path="layers/meta-security" revision="16c68aae0fdfc20c7ce5cf4da0a9fff8bdd75769"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="3713277e2e52e35e5e24cf8b2b2003bedf33ffcf"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -14,7 +14,7 @@
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="0b0ab6a2d227f22374268d29fcb8e4f9dab5374b"/>
   <project name="meta-rust" path="layers/meta-rust" revision="1b59fd45906082c978d0a0a6e4e51a0ea4aa32c7"/>
   <project name="meta-security" path="layers/meta-security" revision="16c68aae0fdfc20c7ce5cf4da0a9fff8bdd75769"/>
-  <project name="meta-updater" path="layers/meta-updater" revision="a0d9835bad4c86416323b1055315fc1fb09bcde5"/>
+  <project name="extra/meta-updater" path="layers/meta-updater" revision="3713277e2e52e35e5e24cf8b2b2003bedf33ffcf"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="be2c9d6efe545ec6718902be9c56a698662ff055"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="e95ccf6f7fe5a42fffcfa5e43087ff964622e26c"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -13,7 +13,7 @@
   <project name="meta-clang" path="layers/meta-clang" revision="2207df98559afc19d6a0243027bbac18980fc764"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="f859d299e655d92e1183ccc24a4f96c122a4ac41"/>
   <project name="meta-rust" path="layers/meta-rust" revision="1b59fd45906082c978d0a0a6e4e51a0ea4aa32c7"/>
-  <project name="meta-security" path="layers/meta-security" revision="16c68aae0fdfc20c7ce5cf4da0a9fff8bdd75769"/>
+  <project name="meta-security" path="layers/meta-security" revision="c40e1e84da9624b9096a463dbed3b301c01c268e"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="3713277e2e52e35e5e24cf8b2b2003bedf33ffcf"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="be2c9d6efe545ec6718902be9c56a698662ff055"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="e95ccf6f7fe5a42fffcfa5e43087ff964622e26c"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -8,7 +8,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="25e9cbddbd32802634bafef62ba08da9821c604d"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="bcfa0798fe44452b1834b298b0ca8147c2469e43"/>
   <project name="meta-intel" path="layers/meta-intel" revision="2e9af208460e0256607a03bba6c0b251173ba075"/>
-  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0dc08f973725e6be1ad5156e1c995e94399f69d5"/>
+  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="b4ec97e4eb8e36efd1f7e2f8ae020a9e55cfc239"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="3d3801aff75cf1f4cd8257346c2776357ab4bd62"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="98b2b2c34f186050e6092bc4f17ecb69aef6148a"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="d9834b916ebd2831b2137d4c2a25d79ac3afb0e0"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -7,7 +7,7 @@
   <project name="meta-arm" path="layers/meta-arm" revision="71686ac05c34e53950268bfe0d52c3624e78c190"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="25e9cbddbd32802634bafef62ba08da9821c604d"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="bcfa0798fe44452b1834b298b0ca8147c2469e43"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="5c4a6b02f650a99a5ec55561443fcf880a863d19"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="2e9af208460e0256607a03bba6c0b251173ba075"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0dc08f973725e6be1ad5156e1c995e94399f69d5"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="3d3801aff75cf1f4cd8257346c2776357ab4bd62"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="98b2b2c34f186050e6092bc4f17ecb69aef6148a"/>


### PR DESCRIPTION
This also includes the switch to the uptane-based meta-updater layer (no change).