### PR TITLE
Initial patchset to include kirkstone support

### DIFF
--- a/conf/bblayers-bsp.inc
+++ b/conf/bblayers-bsp.inc
@@ -7,20 +7,20 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-arm/meta-arm \
   ${OEROOT}/layers/meta-arm/meta-arm-toolchain \
   ${OEROOT}/layers/meta-arm/meta-arm-bsp \
-  ${OEROOT}/layers/meta-freescale \
-  ${OEROOT}/layers/meta-freescale-3rdparty \
   ${OEROOT}/layers/meta-raspberrypi \
   ${OEROOT}/layers/meta-riscv \
-  ${OEROOT}/layers/meta-rtlwifi \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
-  ${OEROOT}/layers/meta-xilinx/meta-xilinx-core \
-  ${OEROOT}/layers/meta-xilinx/meta-xilinx-bsp \
-  ${OEROOT}/layers/meta-xilinx/meta-xilinx-standalone \
-  ${OEROOT}/layers/meta-xilinx-tools \
-  ${OEROOT}/layers/meta-ti \
-  ${OEROOT}/layers/meta-st-stm32mp \
   ${OEROOT}/layers/meta-tegra \
-  ${OEROOT}/layers/meta-sunxi \
   ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "
+# ${OEROOT}/layers/meta-freescale
+# ${OEROOT}/layers/meta-freescale-3rdparty
+# ${OEROOT}/layers/meta-rtlwifi
+# ${OEROOT}/layers/meta-xilinx/meta-xilinx-core
+# ${OEROOT}/layers/meta-xilinx/meta-xilinx-bsp
+# ${OEROOT}/layers/meta-xilinx/meta-xilinx-standalone
+# ${OEROOT}/layers/meta-xilinx-tools
+# ${OEROOT}/layers/meta-ti
+# ${OEROOT}/layers/meta-st-stm32mp
+# ${OEROOT}/layers/meta-sunxi

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -14,6 +14,6 @@
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="bb2b5b31a80eb164e47649036878773614e4dbdf"/>
   <project name="meta-security" path="layers/meta-security" revision="93f2146211001ee3cf697d8428969cc3069ed6ba"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="826542ac128fb6974d10f9b6b996f663b8760c7e"/>
-  <project name="meta-virtualization" path="layers/meta-virtualization" revision="bd7511c53b921c9ce4ba2fdb42778ca194ebc3e8"/>
+  <project name="meta-virtualization" path="layers/meta-virtualization" revision="21a5c29a10f033859f6e44aa035161befa439128"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="75e47b96d8cf82ec4a7fa3225c7fbb5b6ab62b02"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5cc7c93c9556f03693f5c822bbce2ab1a0be3078"/>
   <project name="meta-clang" path="layers/meta-clang" revision="85d956d95401479ca666139e31f662f60c156d5f"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="bb2b5b31a80eb164e47649036878773614e4dbdf"/>
-  <project name="meta-security" path="layers/meta-security" revision="fb77606aef461910db4836bad94d75758cc2688c"/>
+  <project name="meta-security" path="layers/meta-security" revision="93f2146211001ee3cf697d8428969cc3069ed6ba"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="bbbc6409ab5322bc130417bfb34ab9c41a783095"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="bd7511c53b921c9ce4ba2fdb42778ca194ebc3e8"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="75e47b96d8cf82ec4a7fa3225c7fbb5b6ab62b02"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5cc7c93c9556f03693f5c822bbce2ab1a0be3078"/>
   <project name="meta-clang" path="layers/meta-clang" revision="85d956d95401479ca666139e31f662f60c156d5f"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="a19d1802b15fe07e9b1e7584ff9af7c33bfe642a"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="bb2b5b31a80eb164e47649036878773614e4dbdf"/>
   <project name="meta-security" path="layers/meta-security" revision="fb77606aef461910db4836bad94d75758cc2688c"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="bbbc6409ab5322bc130417bfb34ab9c41a783095"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="bd7511c53b921c9ce4ba2fdb42778ca194ebc3e8"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5cc7c93c9556f03693f5c822bbce2ab1a0be3078"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="main-next"/>
   <project name="meta-clang" path="layers/meta-clang" revision="85d956d95401479ca666139e31f662f60c156d5f"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="bb2b5b31a80eb164e47649036878773614e4dbdf"/>
   <project name="meta-security" path="layers/meta-security" revision="93f2146211001ee3cf697d8428969cc3069ed6ba"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -10,7 +10,7 @@
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5cc7c93c9556f03693f5c822bbce2ab1a0be3078"/>
-  <project name="meta-clang" path="layers/meta-clang" revision="088904d40231d9e099c2f5039cd3c2bc47d332d1"/>
+  <project name="meta-clang" path="layers/meta-clang" revision="85d956d95401479ca666139e31f662f60c156d5f"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a19d1802b15fe07e9b1e7584ff9af7c33bfe642a"/>
   <project name="meta-security" path="layers/meta-security" revision="fb77606aef461910db4836bad94d75758cc2688c"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="bbbc6409ab5322bc130417bfb34ab9c41a783095"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="93f2146211001ee3cf697d8428969cc3069ed6ba"/>
   <project name="extra/meta-updater" path="layers/meta-updater" revision="826542ac128fb6974d10f9b6b996f663b8760c7e"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="21a5c29a10f033859f6e44aa035161befa439128"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="75e47b96d8cf82ec4a7fa3225c7fbb5b6ab62b02"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="ca1c990df62f1b3d53b2114a387f192efe7e38e8"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="c039182c79e2ccc54fff5d7f4f266340014ca6e0"/>
+  <project name="bitbake" revision="c212b0f3b542efa19f15782421196b7f4b64b0b9"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -13,7 +13,7 @@
   <project name="meta-clang" path="layers/meta-clang" revision="85d956d95401479ca666139e31f662f60c156d5f"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="bb2b5b31a80eb164e47649036878773614e4dbdf"/>
   <project name="meta-security" path="layers/meta-security" revision="93f2146211001ee3cf697d8428969cc3069ed6ba"/>
-  <project name="extra/meta-updater" path="layers/meta-updater" revision="bbbc6409ab5322bc130417bfb34ab9c41a783095"/>
+  <project name="extra/meta-updater" path="layers/meta-updater" revision="826542ac128fb6974d10f9b6b996f663b8760c7e"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="bd7511c53b921c9ce4ba2fdb42778ca194ebc3e8"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="75e47b96d8cf82ec4a7fa3225c7fbb5b6ab62b02"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -7,7 +7,7 @@
   <project name="meta-arm" path="layers/meta-arm" revision="50b34c5cc9496441152ad28bf1022e5fc5ab0a7e"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="ecbcb80555c470887b9389be803bdc27ab140e1d"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="d323df3f5c651fc17ce0d37cf9de8bbc04dde67a"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="daf5c125a744d45d8fa395b576147edd5a714f5c"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="33421d8a0f74f1d879f6228fcdedce39eb34420b"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="378d4b6e7ba64b6a9a701457cc3780fa896ba5dc"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="9561639c61663a10d8c9c23d26173db499f4c39b"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="98b2b2c34f186050e6092bc4f17ecb69aef6148a"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -12,7 +12,7 @@
   <project name="meta-riscv" path="layers/meta-riscv" revision="70e099d7ceca52a1dde2c978713012f6b20a9891"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="98b2b2c34f186050e6092bc4f17ecb69aef6148a"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="7f8742c1e0cb848067e4b52ca78333ae70b79181"/>
-  <project name="meta-yocto" path="layers/meta-yocto" revision="926a514ddb62d638d05ee94714d4186db26d318e"/>
+  <project name="meta-yocto" path="layers/meta-yocto" revision="fa0884372892d43e76c4d3b4486f1851e39edac3"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" revision="f7d26af60681af1d44ca1b25593924e55b931d69"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" revision="fa689ad7e2b97951f12f3ef7a52685f9555d162d"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="e28a08d63c66563cc41ba57d0bb58b6be2c5d32c"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -15,7 +15,7 @@
   <project name="meta-yocto" path="layers/meta-yocto" revision="fa0884372892d43e76c4d3b4486f1851e39edac3"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" revision="f7d26af60681af1d44ca1b25593924e55b931d69"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" revision="fa689ad7e2b97951f12f3ef7a52685f9555d162d"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="e28a08d63c66563cc41ba57d0bb58b6be2c5d32c"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="bd08f8450581882c5ae39de27869637c18f616cd"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="7dcc9a0069f30d99f5ec9cec9a3b7d9064f8c3f7"/>
   <project name="meta-ti" path="layers/meta-ti" revision="ea5b431bdac13759d1dab20a8d6e3d26a16a5501"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -4,7 +4,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="meta-arm" path="layers/meta-arm" revision="142ec9b8f99759a1caaa5380b3276e99e5e698cf"/>
+  <project name="meta-arm" path="layers/meta-arm" revision="50b34c5cc9496441152ad28bf1022e5fc5ab0a7e"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="ecbcb80555c470887b9389be803bdc27ab140e1d"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="d323df3f5c651fc17ce0d37cf9de8bbc04dde67a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="daf5c125a744d45d8fa395b576147edd5a714f5c"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -9,7 +9,7 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="d323df3f5c651fc17ce0d37cf9de8bbc04dde67a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="33421d8a0f74f1d879f6228fcdedce39eb34420b"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0135a02ea577bd39dd552236ead2c5894d89da1d"/>
-  <project name="meta-riscv" path="layers/meta-riscv" revision="9561639c61663a10d8c9c23d26173db499f4c39b"/>
+  <project name="meta-riscv" path="layers/meta-riscv" revision="70e099d7ceca52a1dde2c978713012f6b20a9891"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="98b2b2c34f186050e6092bc4f17ecb69aef6148a"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="7f8742c1e0cb848067e4b52ca78333ae70b79181"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="926a514ddb62d638d05ee94714d4186db26d318e"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -8,7 +8,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="ecbcb80555c470887b9389be803bdc27ab140e1d"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="d323df3f5c651fc17ce0d37cf9de8bbc04dde67a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="33421d8a0f74f1d879f6228fcdedce39eb34420b"/>
-  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="378d4b6e7ba64b6a9a701457cc3780fa896ba5dc"/>
+  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0135a02ea577bd39dd552236ead2c5894d89da1d"/>
   <project name="meta-riscv" path="layers/meta-riscv" revision="9561639c61663a10d8c9c23d26173db499f4c39b"/>
   <project name="meta-rtlwifi" path="layers/meta-rtlwifi" revision="98b2b2c34f186050e6092bc4f17ecb69aef6148a"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="7f8742c1e0cb848067e4b52ca78333ae70b79181"/>

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -136,7 +136,7 @@ export PATH=$(echo "$PATH" |
         awk -F: '{for (i=1;i<=NF;i++) { if ( !x[$i]++ ) printf("%s:",$i); }}' |
         sed 's/:$//')
 # Make sure Bitbake doesn't filter out the following variables from our env
-export BB_ENV_EXTRAWHITE="MACHINE DISTRO TCLIBC TCMODE GIT_PROXY_COMMAND \
+export BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE DISTRO TCLIBC TCMODE GIT_PROXY_COMMAND \
         http_proxy ftp_proxy https_proxy all_proxy ALL_PROXY no_proxy \
         SSH_AGENT_PID SSH_AUTH_SOCK BB_SRCREV_POLICY SDKMACHINE \
         BB_NUMBER_THREADS BB_LOGCONFIG BB_CONSOLELOG"


### PR DESCRIPTION
* meta-lmp uses the main-next branch instead of a commit id
* so far some BSP metalayers are disabled by default
depends on https://github.com/foundriesio/meta-lmp/pull/626/
