### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5cc7c93c9556f03693f5c822bbce2ab1a0be3078"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3e38a32357b8c1cf5ae8581435355834b02eb54d"/>
   <project name="meta-clang" path="layers/meta-clang" revision="088904d40231d9e099c2f5039cd3c2bc47d332d1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a19d1802b15fe07e9b1e7584ff9af7c33bfe642a"/>
   <project name="meta-security" path="layers/meta-security" revision="fb77606aef461910db4836bad94d75758cc2688c"/>


### PR DESCRIPTION
Relevant changes:
- 3e38a323 base: kmeta-linux-lmp-5.10.y: bump to abe5439
- fbcc722f base: kmeta-linux-lmp-5.10.y: bump to 38a542bd83e7
- 0d994e03 versal: xsa: use xilinx-k26-starterkit-v2021.1-final.bsp
- 03b67ea0 versal: kernel command line: do not disable unused clocks
- 9d1aaab1 base: lmp-feature-optee: drop sks, examples and pkcs11test
- 16261738 base: lmp: define ETC_PASSWD_MEMBERS for /etc/passwd mirroring
- 8e1df8ae base: lmp-device-register: add pkgconfig

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>