### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5cc7c93c9556f03693f5c822bbce2ab1a0be3078"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4e73d1310125c083ce41ebca0a2abe97ebe2b936"/>
   <project name="meta-clang" path="layers/meta-clang" revision="088904d40231d9e099c2f5039cd3c2bc47d332d1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a19d1802b15fe07e9b1e7584ff9af7c33bfe642a"/>
   <project name="meta-security" path="layers/meta-security" revision="fb77606aef461910db4836bad94d75758cc2688c"/>


### PR DESCRIPTION
Relevant changes:
- 4e73d131 base: lmp-feature-docker: switch to the golang based compose
- dc2d343e base: docker-compose: update to 2.5.0
- e76d5579 bsp: u-boot-ostree-scr-fit: kv260: add initial boot.cmd
- 8893c3ed bsp: xilinx: arm-trusted-firmware: enable optee only for uz
- c7bd293a bsp: xilinx: arm-trusted-firmware: kv260: provide correct uart
- 704acc89 base: u-boot-ostree-scr-fit: common: custom handling of update
- 51a39324 bsp: u-boot-xlnx: k62: drop bootcount feature
- 6c3f311b bsp: u-boot-xlnx: k62: add qspi configuration
- f70e7896 base: u-boot-ostree-scr-fit: common: extend debug output
- 213e6617 base: u-boot-ostree-scr-fit: common: add support for redefining bootcmd
- f1ad7ba1 base: recipe-sota: aktualizr-lite: bump to 96640d2
- ae47953f bsp: lmp-machine-custom: stm32mp1: prefer optee-os-fio
- 3168f3ab bsp: lmp-machine-custom: mx8: bump optee to 3.17.0
- 796af636 base: pkcs11-se050-import: use optee-os-tadevkit for building the TA
- 5755e950 base: optee-sks: use optee-os-tadevkit for building the TA
- 2181593c base: optee-fiovb: build TA by leveraging optee-os-tadevkit
- 9018182d base: optee-test: update to 3.17.0
- 36507575 base: optee-examples: update to 3.17.0
- ed5013b1 base: optee-client: update to 3.17.0
- d9d2e157 base/bsp: update optee-os to 3.17.0
- 01d8aa1c bsp: u-boot-xlnx: 2022.01: bump to aba57774e46
- 1de5627e bsp: u-boot-xlnx: 2022.01: bump to 34fda873c0d
- ec9b2aac bsp: u-boot-ostree-scr-fit: imx8qm: drop update_image_boot1
- 0f877e6e linux: kmeta-linux-lmp: 5.10: bump to 423dc80
- 70cfd263 base: kmeta-linux-lmp-5.10.y: bump to abe5439
- bacdf31a base: kmeta-linux-lmp-5.10.y: bump to 38a542bd83e7
- 30270ef3 versal: xsa: use xilinx-k26-starterkit-v2021.1-final.bsp
- edc102d2 versal: kernel command line: do not disable unused clocks
- daff6cfe base: lmp-feature-optee: drop sks, examples and pkcs11test
- 147616f5 base: lmp: define ETC_PASSWD_MEMBERS for /etc/passwd mirroring
- c02595ba base: optee-test-fio: Fix LICENSE use the right SPDX tag
- 4bda73da base: optee-fiovb: Fix LICENSE to match the package
- 59e4f3cf bsp: bitstream-signed: Remove one LICENSE
- f796796e base: python3-func-timeout: Fix the LICENSE to match the package
- d69647f6 bsp: convert LICENSE to use SPDX tags
- 8c5f13ef base: convert LICENSE to use SPDX tags
- 70443aeb base: optee*: python3-pycrypto: Remove obsolete pycrypto module
- c07cdc8f base: optee-test: Avoid build error
- f067d46f base: lmp-device-register: add pkgconfig
- 599b28a2 bsp: linux-firmware: Include SRCREV for all the sources

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>