### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9cd9375c3d710029ae73faeca50a9049ff56e14b"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="b86e4b46c056ac3124f22082f563a5501ac78a48"/>
   <project name="meta-clang" path="layers/meta-clang" revision="088904d40231d9e099c2f5039cd3c2bc47d332d1"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a19d1802b15fe07e9b1e7584ff9af7c33bfe642a"/>
   <project name="meta-security" path="layers/meta-security" revision="fb77606aef461910db4836bad94d75758cc2688c"/>


### PR DESCRIPTION
Relevant changes:
- 187a3fc9 bsp: imx8mp-lpddr4-evk-sec: add fiovb to machine features
- 1796543c base: optee-os-fio: make append more generic
- bf339f45 base/bsp: migrate fiovb to MACHINE_FEATURES
- 056d0a00 bsp: qemuarm64-secureboot-ebbr: fix machine overrides order
- 8734fe11 bsp: imx8mq-evk-ebbr: fix machine overrides order
- d87d0f66 bsp: imx8mp-lpddr4-evk-ebbr: fix machine overrides order
- 29599fcf bsp: imx8mm-lpddr4-evk-ebbr: fix machine overrides order
- f414a51b bsp: imx8mm-lpddr4-evk-sec: fix machine overrides order
- 896d83b9 bsp: imx6ullevk-sec: fix machine overrides order
- 805df75e bsp: apalis-imx6-sec: fix machine overrides order
- bc3b8cc0 Revert "bsp: xilinx: arm-trusted-firmware: enable optee only for uz"
- 8f921116 bsp: xilinx: device-tree: add optee node
- 650b2c82 bsp: optee-os-fio: provide correct uart configuration for kv260
- 6aff631b base: optee-os-fio: 3.17: bump to 7d80513fb

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>