### PR TITLE
bsp: drop meta-riscv from default layer list

### DIFF
--- a/conf/bblayers-bsp.inc
+++ b/conf/bblayers-bsp.inc
@@ -8,7 +8,6 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-arm/meta-arm-toolchain \
   ${OEROOT}/layers/meta-arm/meta-arm-bsp \
   ${OEROOT}/layers/meta-raspberrypi \
-  ${OEROOT}/layers/meta-riscv \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
   ${OEROOT}/layers/meta-xilinx/meta-xilinx-core \

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -10,7 +10,6 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="d323df3f5c651fc17ce0d37cf9de8bbc04dde67a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="fb23bc3e661685383edd3026e21ca25825c48bc4"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0135a02ea577bd39dd552236ead2c5894d89da1d"/>
-  <project name="meta-riscv" path="layers/meta-riscv" revision="70e099d7ceca52a1dde2c978713012f6b20a9891"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="89ec4a320bc14673a2caf820b87bbecc77a624f3"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="fa0884372892d43e76c4d3b4486f1851e39edac3"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="531a6d3fda872a342dd9ac9d5619c7f544012355"/>


### PR DESCRIPTION
Not used by the officially supported targets, so drop from the default
bsp layer list to reduce maintenance.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>