### PR TITLE
meta-xilinx and freescale related updates for kirkstone

### DIFF
--- a/conf/bblayers-bsp.inc
+++ b/conf/bblayers-bsp.inc
@@ -7,6 +7,8 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-arm/meta-arm \
   ${OEROOT}/layers/meta-arm/meta-arm-toolchain \
   ${OEROOT}/layers/meta-arm/meta-arm-bsp \
+  ${OEROOT}/layers/meta-freescale \
+  ${OEROOT}/layers/meta-freescale-3rdparty \
   ${OEROOT}/layers/meta-raspberrypi \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
@@ -20,5 +22,3 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-sunxi \
   ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "
-# ${OEROOT}/layers/meta-freescale
-# ${OEROOT}/layers/meta-freescale-3rdparty

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="2683960c04185b7704c9d6739f8805dff53d025f"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="2aa3b9a5d47c82ed14623b62256bec9bc034611b"/>
   <project name="meta-clang" path="layers/meta-clang" revision="85d956d95401479ca666139e31f662f60c156d5f"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="0b78362654262145415df8211052442823b9ec9b"/>
   <project name="meta-security" path="layers/meta-security" revision="0325071a1d12f132e9f260a03eb63b8d46b328a8"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -12,7 +12,7 @@
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0135a02ea577bd39dd552236ead2c5894d89da1d"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="89ec4a320bc14673a2caf820b87bbecc77a624f3"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="fa0884372892d43e76c4d3b4486f1851e39edac3"/>
-  <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="531a6d3fda872a342dd9ac9d5619c7f544012355"/>
+  <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="bac5f428e9948cbc373f2ae891c0c9c8fa0fc45d"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="bd08f8450581882c5ae39de27869637c18f616cd"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="fdce4f86744d21dfa53e1e3c9b4eb6302a8edf98"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="50b34c5cc9496441152ad28bf1022e5fc5ab0a7e"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="ecbcb80555c470887b9389be803bdc27ab140e1d"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="2fb1ce365338126aad365012ebb913b3e4a9f1be"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="d323df3f5c651fc17ce0d37cf9de8bbc04dde67a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="fb23bc3e661685383edd3026e21ca25825c48bc4"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0135a02ea577bd39dd552236ead2c5894d89da1d"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -7,7 +7,7 @@
 
   <project name="meta-arm" path="layers/meta-arm" revision="50b34c5cc9496441152ad28bf1022e5fc5ab0a7e"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="2fb1ce365338126aad365012ebb913b3e4a9f1be"/>
-  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="d323df3f5c651fc17ce0d37cf9de8bbc04dde67a"/>
+  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="de0eb1408150d77f9cce97c559f9a5a3c71e5d6c"/>
   <project name="meta-intel" path="layers/meta-intel" revision="fb23bc3e661685383edd3026e21ca25825c48bc4"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0135a02ea577bd39dd552236ead2c5894d89da1d"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="89ec4a320bc14673a2caf820b87bbecc77a624f3"/>


### PR DESCRIPTION
This should unblock all the xilinx/freescale builds.

Only one remaining will be am64xx.