### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="2aa3b9a5d47c82ed14623b62256bec9bc034611b"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7765e172b0d5631605d1ea73229b0062a640cde6"/>
   <project name="meta-clang" path="layers/meta-clang" revision="85d956d95401479ca666139e31f662f60c156d5f"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="0b78362654262145415df8211052442823b9ec9b"/>
   <project name="meta-security" path="layers/meta-security" revision="0325071a1d12f132e9f260a03eb63b8d46b328a8"/>


### PR DESCRIPTION
Relevant changes:
- aab60d95 bsp: u-boot-xlnx: 2022.01: bump to 7c9f39b98b
- b079ec7c base: ostree: add upstream-status to local patches
- 1ad1c6ab bsp: u-boot-ostree-scr-fit: qemuarm64: add support for booting recovery img
- a15a2a5d bsp: u-boot-fio: qemuarm64: enforce env load at boot
- c9d163f1 base: lmp-image-common: add ostree-recovery-initramfs
- b62cdd0b base: ostree-kernel-initramfs: add support for recovery image
- 227f368d base: kernel-lmp-fitimage: add support for creating a recovery fit image
- b3a2ae96 base: add initial support for lmp recovery image
- c386510c base: ostree: improve ostree-boot handling logic
- 90232863 base: lmp: Add KVM support to RPi4
- 76943b99 bsp: qemuarm64-secureboot: enable ostree split boot usage
- 7747046b base: lmp: use no-fstab-update on wic when sota
- 44bfd505 base: wic: add sdimage-split-boot-sota.wks.in
- f7fec392 base: lmp: add support to split ostree boot
- 7e502a23 base: lmp: remove boot files installed by OE
- df5fd43c base: ostree: add patches to support ostree-boot files
- bac64e05 bsp: u-boot-ostree-scr-fit: kv260: probe spi before every op
- 14a54c92 base: u-boot-ostree-scr-fit: adjust secondary boot path
- 481e0682 base: u-boot-ostree-scr-fit: adjust secondary boot path handling

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>