### PR TITLE
tegra nvcc gcc fix

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -14,7 +14,7 @@
   <project name="meta-yocto" path="layers/meta-yocto" revision="79b0270f55d69ecae8ada6dce492b7c561c56cca"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="bac5f428e9948cbc373f2ae891c0c9c8fa0fc45d"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="bd08f8450581882c5ae39de27869637c18f616cd"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="cba0ea0a016d1072f119cfcbf64802c62e125c72"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="fdce4f86744d21dfa53e1e3c9b4eb6302a8edf98"/>
   <project name="meta-ti" path="layers/meta-ti" revision="2124e7ecd88d1aded320e86da62785c3ab171b27"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -14,7 +14,7 @@
   <project name="meta-yocto" path="layers/meta-yocto" revision="79b0270f55d69ecae8ada6dce492b7c561c56cca"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="bac5f428e9948cbc373f2ae891c0c9c8fa0fc45d"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="cba0ea0a016d1072f119cfcbf64802c62e125c72"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="e8819e9a2a03b768fdd46788578f36e8bf0316c4"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="fdce4f86744d21dfa53e1e3c9b4eb6302a8edf98"/>
   <project name="meta-ti" path="layers/meta-ti" revision="2124e7ecd88d1aded320e86da62785c3ab171b27"/>
 </manifest>


### PR DESCRIPTION

Include fixes for https://github.com/foundriesio/meta-lmp/pull/694

The meta-tegra layer when enabled is superimposing its gcc inc files [1]
and e currently don't use the oe-core file at [2].

[1] meta-tegra/recipes-devtools/gcc/gcc-source.inc
[2] openembedded-core/meta/recipes-devtools/gcc/gcc-source.inc