### PR TITLE
Move lmp-mirrors to GitHub

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote fetch="https://github.com/foundriesio" name="fio"/>
-  <remote fetch="https://source.foundries.io/lmp-mirrors" name="lmp-mirrors"/>
+  <remote fetch="https://github.com/lmp-mirrors" name="lmp-mirrors"/>
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
@@ -13,7 +13,7 @@
   <project name="meta-clang" path="layers/meta-clang" revision="cd7b2f8c90962bef4e8b272ce6863a57b73f20fc"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="fcc7d7eae82be4c180f2e8fa3db90a8ab3be07b7"/>
   <project name="meta-security" path="layers/meta-security" revision="d3d8e62bf1caa3870a504c0addcfd200b33c189f"/>
-  <project name="extra/meta-updater" path="layers/meta-updater" revision="6f3016da1bb822c055609053871472593979e8cc"/>
+  <project name="meta-updater" path="layers/meta-updater" revision="6f3016da1bb822c055609053871472593979e8cc"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="b70d6bb35734c3863051098eb2dd3c2dbe11c92f"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="c20a5f83e9f0483f5458513eeaaec60436dd9d68"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote fetch="https://github.com/foundriesio" name="fio"/>
-  <remote fetch="https://source.foundries.io/lmp-mirrors" name="lmp-mirrors"/>
+  <remote fetch="https://github.com/lmp-mirrors" name="lmp-mirrors"/>
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 


### PR DESCRIPTION
We are now mirroring everything from source.foundries.io to GitHub. This
will allow us to offload quite a bit of traffic from our Git servers.

Signed-off-by: Andy Doan <andy@foundries.io>