### PR TITLE
Setup: Create a location for customer custom uefi keys keys

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -200,6 +200,11 @@ if [ -d "${MANIFESTS}"/factory-keys ]; then
         ln -sf "${MANIFESTS}"/factory-keys/privkey_modsign.pem conf/factory-keys/privkey_modsign.pem
         ln -sf "${MANIFESTS}"/factory-keys/x509_modsign.crt conf/factory-keys/x509_modsign.crt
     fi
+
+    # Link custom UEFI development keys and certificates set by the user
+    if [ -d "${MANIFESTS}"/factory-keys/uefi -a ! -d "conf/factory-keys/uefi" ]; then
+        ln -sf "${MANIFESTS}"/factory-keys/uefi conf/factory-keys/uefi
+    fi
 fi
 
 # Link default iMX HAB4 development keys and certificate if not set by the user


### PR DESCRIPTION
Customer may want to have their own keys, just like the other CI keys. so have a place to put them.

Signed-off-by: Tim Anderson <tim.anderson@foundries.io>