### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="36c3842013965cc7e71e88ac29f480242bf904e2"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="ce3d9641e3a7e6fd69f08aa651676358ece5f2b4"/>
   <project name="meta-clang" path="layers/meta-clang" revision="cd7b2f8c90962bef4e8b272ce6863a57b73f20fc"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="fcc7d7eae82be4c180f2e8fa3db90a8ab3be07b7"/>
   <project name="meta-security" path="layers/meta-security" revision="d3d8e62bf1caa3870a504c0addcfd200b33c189f"/>


### PR DESCRIPTION
Relevant changes:
- ce3d9641 bsp: linux-lmp-ea-imx: update to linux-ea-v5.10.72

Signed-off-by: Vanessa Maegima <vanessa.maegima@foundries.io>