### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="88a4c0bf5880e4dfdca7a8233b21b8a1219424e2"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="664bb9d85658687e34294dd64bf82db430604a43"/>
   <project name="meta-clang" path="layers/meta-clang" revision="d669d873edf68dc7440bb07096737203bb7ec505"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="fb7b26b0fb243620f52a61296f4eda6af6ad1af6"/>
   <project name="meta-security" path="layers/meta-security" revision="d3d8e62bf1caa3870a504c0addcfd200b33c189f"/>


### PR DESCRIPTION
Relevant changes:
- 664bb9d8 bsp: wpa-supplicant: disable control port over nl80211 for imx8mm-evk
- 1249f7fd recipe-support: resize-helper needs to preserve PART_ENTRY_NAME
- fa1a1989 base: images: install i2c-tools package
- 21eaea98 bsp: linux-firmware: stm32: fix brcmfmac43430-sdio.txt

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>