### PR TITLE
Dockerfile: Add docker CLI and compose CLI plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,3 +86,15 @@ ENV FIO_CHECK_CMD /usr/bin/fiocheck
 
 # Install skopeo
 COPY --from=container-tools /skopeo/bin/skopeo /usr/bin
+
+# Install docker CLI, v20.10.14, required by the oe-builtin App preload
+RUN mkdir -p /etc/apt/keyrings \
+	&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
+	&& apt-get update && apt-get install -y docker-ce-cli=5:20.10.14~3-0~ubuntu-focal \
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install docker compose CLI plugin, v2.6.0, required by the oe-builtin App preload, `docker compose config`
+RUN mkdir -p /usr/lib/docker/cli-plugins \
+	&& wget https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -O /usr/lib/docker/cli-plugins/docker-compose \
+	&& chmod +x /usr/lib/docker/cli-plugins/docker-compose


### PR DESCRIPTION
The "oe-builtin" App preload requires `docker compose` utility since
we moved from the python-based `docker-compose` to the golang-based
plugin of `docker` CLI utility.

Signed-off-by: Mike <mike.sul@foundries.io>