### PR TITLE
Dockerfile: Fix regression for oe-prebuilt logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update \
 		tmux libncurses-dev vim zstd lz4 liblz4-tool libc6-dev-i386 \
 		awscli docker-compose \
 	&& ln -s /usr/bin/python3 /usr/bin/python \
-	&& pip3 --no-cache-dir install jsonFormatter \
+	&& pip3 --no-cache-dir install expandvars jsonFormatter \
 	&& apt-get autoremove -y \
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
ci-scripts now has support for SBOM stuff which introduced a change to
our compose_apps.py module. compose_apps.py now uses python3's
expandvars package.

Signed-off-by: Andy Doan <andy@foundries.io>