### PR TITLE
lmp-bsp: Bump meta-freescale

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="f2781a9c8df0e9b09c6cac498e506ce2f882c2d6"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="2fb1ce365338126aad365012ebb913b3e4a9f1be"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="cdc56a683fe009ea2889ea6354d3a44b562454d7"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="de0eb1408150d77f9cce97c559f9a5a3c71e5d6c"/>
   <project name="meta-intel" path="layers/meta-intel" revision="032466fb6effc05d5c13994ef2168480a7af0b4b"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="0135a02ea577bd39dd552236ead2c5894d89da1d"/>


### PR DESCRIPTION
Relevant changes:
- cdc56a68 Merge pull request #1169 from thochstein/fsl-eula-unpack
- 98275f87 fsl-eula-unpack.bbclass: Expose a function for reuse
- 42458b25 fsl-eula-unpack.bbclass: Rework logic order
- 4f9ab862 fsl-eula-unpack.bbclass: Fail if fsl-eula=true is missing
- effeb16a Merge pull request #1147 from angolini/update-lf-5.15.5-2.0.0
- 621127a7 linux-fslc-imx: upgrade to lf-5.15.5-2.0.0 from NXP
- cbc9e846 Merge pull request #1165 from thochstein/fix-u-boot-imx-dependency
- 4b7afb6b u-boot-imx: Add missing gnutls dependency
- 80dfd0f1 Merge pull request #1163 from thochstein/uboot-machine-config
- 52679890 imx-base.inc: Expand comment for UBOOT_SUFFIX
- 6569140c imx6ulevk.conf: Add missing overrides for u-boot-imx-mfgtool
- d3f8b15d imx8m*: Drop redundant UBOOT_SUFFIX assignment
- 79d3af06 Merge pull request #1161 from thochstein/imx8mq-evk
- 15be26ce imx8mq-evk.conf: Extend fix for `u-boot-imx` and `u-boot-fslc`
- 865cfdfd Merge pull request #1160 from thochstein/optee
- dbcc587e optee-os: Fix PLATFORM_FLAVOR overrides for 6UL, 6ULL, and 6ULZ
- d5abe2b1 optee: Upgrade 3.15.0.imx -> 3.17.0.imx
- d29b35ed Merge pull request #1158 from Freescale/topic/fix-u-boot-imx
- 1650359b imx8m*-evk: allow switch between `u-boot-imx` and `u-boot-fslc`
- d70a83fb Merge pull request #1155 from WallaceIT/localversion_devtool_fix
- 5d96d634 classes: fsl-kernel-localversion: fix usage with devtool
- e195433d Merge pull request #1152 from thochstein/u-boot-imx-mfgtool
- 7effa525 Merge pull request #1141 from Freescale/topic/secure-boot-rework
- 453def79 imx-atf: allow setting the UART used during boot
- 4c5cd39b imx6qdlsabre*.conf: Fix u-boot-imx-mfgtool compile error
- d9148f97 imx6qdlsabre*.conf: Fix UBOOT_CONFIG override for u-boot-imx-mfgtool
- 205b34dc imx-atf: mark `do_configure` as `noexec`
- 09ed3f6a imx-atf: use `MACHINE_ARCH` as `PACKAGE_ARCH`
- 896b5adc imx-atf: avoid default dependencies addition
- 63d73925 imx-base.inc: consolidate `IMX_EXTRA_FIRMWARE` definition
- 0d87d90f Remove unuse `BOOT_TOOLS` variable
- bed09c8d imx-base.inc: avoid explicit imx-boot dependency
- fd5438e6 Merge pull request #1148 from Freescale/topic/upgrade-components
- 43534097 imx8mm-evk: lift imx8mm-lpddr4-evk and imx8mm-ddr4-evk restrictions
- cc390c42 Merge pull request #1149 from thochstein/kernel
- 48544d4d u-boot-imx: Upgrade 2021.04 -> 2022.04
- eb934917 linux-imx-headers: Upgrade 5.15.5 -> 5.15.32
- a9c993ea linux-imx: Upgrade to 5.15.32
- a4f0b0c2 EULA,SCR: Update for NXP release 5.15.32-2.0.0
- fc38a34b u-boot-fslc: 2022.04 -> 2022.07
- 388fd2ec imx-atf: update lf-5.15.5-1.0.0 to lf-5.15.32-2.0.0
- c4571b43 Add SoC information in machines where it is missing
- 15098843 Merge pull request #1144 from Freescale/topic/qoirq-rework
- 237f04e8 optee-qoriq: rename directory so it maps to the recipe
- 2f26da88 qoriq-cst: rename cst to qoriq-cst
- 912908ce Merge pull request #1142 from thochstein/master
- 20586ab8 imx-atf: Refine array-bounds patch commit message
- 178ecf0a Merge pull request #1138 from junzhuimx/master
- 1e217136 conf/machine/ls1046ardb.conf: Add DTB fsl-ls1046a-rdb-usdpaa-shared.dtb
- 2953f041 Merge pull request #1133 from MaxKrummenacher/weston
- 32cbeb3c Merge pull request #1134 from MaxKrummenacher/cleanup
- f9ed55e9 Merge pull request #1132 from MaxKrummenacher/master
- ecb8d898 weston: 9.0.0.imx: fix build with latest master
- b670b9f7 remove random file
- c35ef411 Revert "imx-base.inc: upgrade to gstreamer 1.20.2"
- 02870132 Merge pull request #1130 from thochstein/master
- 5b47898f imx-base.inc: Use ??= for PREFERRED_VERSION
- ec669b79 Merge pull request #1127 from loicpoulain/fitsign
- 6824fc66 imx-boot: Use public key injected DTB when FIT signature is enabled
- 9abae91e Merge pull request #1124 from liuming50/fix-vpu-firmware-paths
- 8ba9c05e firmware-imx: create symbolic links for CODA VPU firmwares
- 84e927ac Merge pull request #1122 from angolini/gstreamer
- 912829e1 imx-base.inc: upgrade to gstreamer 1.20.2
- 0a83f1f6 Merge pull request #1119 from lucaceresoli/luca/for-master
- 6af01cbe isp-imx: fix source and build directories
- aee73290 Merge pull request #1117 from MaxKrummenacher/master
- 2f8003c3 vf: follow SoC override changes also for vybrid
- 0fac18a7 Merge pull request #1114 from woutervanh/master
- fa0def54 Update xorg.conf
- 6e2f9b84 libimxvpuapi2: Upgrade to version 2.2.1
- 90a162ed gstreamer1.0-plugins-imx: Upgrade to version 2.1.0
- ecd2701d libimxdmabuffer: Upgrade to version 1.1.2
- 1d9c8ac2 Merge pull request #1112 from zandrey/topic/kernel-update-master
- 3a2cc5d4 recipes-kernel: drop lzop kernel compression
- 7bd94674 linux-fslc-imx: update to v5.15.48
- d7167b36 linux-fslc-lts: update to v5.15.48
- 992bf893 linux-fslc: update to v5.18.5
- c7519dc4 linux-fslc-imx: update to v5.15.47
- 86ad3393 linux-fslc-lts: update to v5.15.47
- 257bfcf2 linux-fslc: update to v5.18.4
- e2df82fd Merge pull request #1110 from thochstein/mfgtool-initramfs
- cca3a8a7 mfgtool-initramfs-image: Fix override of IMAGE_FSTYPES
- 6b56658a Merge pull request #1109 from zandrey/topic/support-upstream-tf-a
- cbea2c36 dynamic-layers: add meta-arm to provide upstream TF-A
- 1ec95400 recipes-bsp: drop custom deploy location for TF-A binary
- b61c4907 layer-wide: define configurable default TF-A provider
- 60f94107 Merge pull request #1104 from dimonoff/master
- 4cc87c7e Merge pull request #1106 from zandrey/topic/kernel-update-master
- 0e7b9cc8 linux-fslc-imx: update to v5.15.46
- 21adc461 linux-fslc-lts: update to v5.15.46
- 030e17a8 linux-fslc: update to v5.18.3
- 0a29050d classes: IMAGE_FSTYPES as weak variable in mfgtool-initramfs-image
- 6072677c Merge pull request #1105 from tprrt/tprrt/delete-itbimage
- d26c197f kernel-itbimage: delete this bbclass
- 8c63ffd1 Merge pull request #1100 from thochstein/opencl
- 0c9f999f imx-base.inc: Set virtual/opencl-icd provider for i.MX
- db6fd7ca Merge pull request #1091 from MaxKrummenacher/master
- c4092fc8 Merge pull request #1099 from zandrey/topic/kernel-update-master
- adc7cf68 linux-fslc-imx: update to v5.15.45
- 3723488a linux-fslc-lts: update to v5.15.45
- 59545284 linux-fslc: update to v5.18.2
- 7f707e22 Merge pull request #1098 from MaxKrummenacher/alsa-lib
- 2a614930 alsa-lib: drop not applying patch
- 5b6422e8 linux-fslc-imx: upgrade to lf-5.15.5-1.0.0 from NXP
- 844898d2 linux-fslc-lts: re-sync configs with upstream
- cb567c26 linux-fslc-lts: upgrade to 5.15.x+fslc
- 5073b41b linux-fslc: drop config option not present in upstream
- f2b2a2bf linux-fslc: re-sync configs with upstream
- 51d7da41 linux-fslc: upgrade to 5.18.x+fslc
- 8770de58 Merge pull request #1096 from zandrey/topic/remove-lzop-native
- af3f03bf layer wide: remove lzop dependency dropped upstream
- 137fb385 Merge pull request #1095 from ricardosalveti/nxp89xx
- cdfee08b kernel-module-nxp89xx: fix compatible machine override
- ac914d2f Merge pull request #1092 from thochstein/optee
- bad9e496 Merge pull request #1093 from sean-anderson-seco/patch-1
- a91c96cc rcw: Use SPDX-style license
- 1d9eb0fc optee-test: Rework the OPTEE_ARCH logic
- f7dae734 optee-os: Simplify OPTEE_ARCH assignment for 32-bit
- cda74c04 kernel-module-isp-vvcam: fix error found by gcc 12
- 39fa6382 Merge pull request #1088 from MaxKrummenacher/master
- 3d6c8ac0 Merge pull request #1090 from tprrt/tprrt/fix-imx-atf-src-uri
- f9b9c7e0 imx-atf: fix patch applying
- 9615f4e7 Merge pull request #1089 from thochstein/imx-atf
- dc3cb910 imx-atf: Suppress array-bounds error
- 5171b4b5 machines: follow kernel deployment changes
- 7d6441d3 Merge pull request #1085 from thochstein/optee-imx
- a11a0895 optee-test: Upgrade to NXP 5.15.5-1.0.0
- f51ff30c optee-client: Update branch, same SRCREV
- 5956fb99 optee-os: Upgrade to NXP 5.15.5-1.0.0
- 7c4ab1f1 Merge pull request #1080 from thochstein/weston
- 8a19c8c5 xwayland: Add patch to fix fbo pixmap on glamor
- a4f772ca xwayland: Add patch to prefer GLES2 for glamor EGL
- d9df3c4e xwayland: Drop GLX for i.MX GPU
- 7a15ffa4 xwayland: Rework i.MX GPU configuration variables
- 7c8cca45 weston: Upgrade to NXP 5.15.5-1.0.0
- 478aaa39 Merge pull request #1078 from thochstein/graphics
- 5c9e9844 imx-g2d-samples: Upgrade 1.0.0 -> 2.0.0
- 015caea5 imx-dpu-g2d: Upgrade 1.9.4 -> 2.0.0
- f20a1735 imx-gpu-g2d: Fix install for multilib
- 89f0d222 imx-gpu-g2d: Upgrade 6.4.3.p2.4 -> 6.4.3.p4.0
- 85348012 Merge pull request #1075 from tprrt/tprrt/fix-imx8m-lpddr4-bsp
- c13204d3 imx8m: Set LPDDR4 machines to use IMX BSP only
- ff5516a0 kernel-module-imx-gpu-viv: Upgrade to 6.4.3.p4.0
- 9b3c563a imx-gpu-viv: Upgrade to 6.4.3.p4.0
- 64121b5a Merge pull request #1070 from thochstein/recipes-bsp
- 6f318efe imx-vpu-hantro-vc: Upgrade 1.6.0 -> 1.7.0
- b50d9f4f imx-vpu-hantro-daemon: Upgrade 1.1.1 -> 1.1.2
- 496d5a1d imx-vpu-hantro: Upgrade 1.24.0 -> 1.25.0
- a26f334b imx-test: Update for NXP release 5.15.5-1.0.0
- 9d815c53 imx-seco-libs: Update for NXP release 5.15.5-1.0.0
- 851b55ca imx-seco: Upgrade 3.8.4 -> 3.8.5
- 03153604 imx-sc-firmware: Upgrade 1.11.0 -> 1.12.1
- 66348498 imx-atf: Update for NXP release 5.15.5-1.0.0
- 8f10c733 imx-mkimage: Update for NXP release 5.15.5-1.0.0
- cb3baf51 firmware-imx: Upgrade 8.14 -> 8.15
- 923b963a EULA,SCR: Update for NXP release 5.15.5-1.0.0
- 9b49f886 Merge pull request #1071 from thochstein/uboot-config
- 3dcc54c2 imx8mp-lpddr4-evk: Add uboot config ndm
- 53df19c4 imx8mn-ddr4-evk: Add uboot config nom
- 17aed5a1 imx8mn-evk: Add uboot config ld
- 40d5578d imx8dxl-lpddr4-evk: Cleanup BOARD_TYPE assignment
- b281aff0 imx8dxl-lpddr4-evk: Add uboot config lcd
- 6b82b2c9 imx8dxl-ddr3l-evk: Add uboot config fspi
- fe3d509c imx8dx-mek: Fix name and description
- e5298eca Merge pull request #1066 from thochstein/kernel
- 0fc7fbbc u-boot-imx-common: Upgrade to NXP 5.15.5-1.0.0 release
- 6d0c1149 linux-imx-headers: Fix do_install
- 7e34c293 linux-imx-headers: Upgrade to 5.15
- 8dab2cfa linux-imx: Upgrade to 5.15.5

Signed-off-by: Daiane Angolini <daiane.angolini@foundries.io>