### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="0bf621e2a7d89053be55d7c03a5d75081a41db61"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="e26e5e6ced98434a0f26cea9b5a4de5bdb5e5777"/>
   <project name="meta-clang" path="layers/meta-clang" revision="7952eba1d16264b605682ae1ccbea4d8c6e9fcac"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="acbe74879807fc6f82b62525d32c823899e19036"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- e26e5e6c base: plug-and-trust-seteec: bump to f9df65c
- bfb4a491 base: lmp-el2go-auto-register: look for libckteec.so.0 (major)
- 2ac49402 bsp: stm-st-stm32mp: tf-a-tools: 2.6 -> 2.7
- 2600b711 bsp: stm-st-stm32mp: tf-a-tools: fix building
- a9a53e8f bsp: stm-st-stm32mp: add tf-a-tools 2.6
- db221196 base: lmp: kmod-native: add openssl to PACKAGECONFIG
- ee84b09f base: u-boot: u-boot-fio_imx-2022.04 decrease preference
- 2bc98b3d base: wireguard-module: update to v1.0.20220627
- dd8d2d5c bsp: lmp-machine-custom: invert the KERNEL_BUILTIN_WIREGUARD logic
- 0a49830b base: wireguard-module: invert the KERNEL_BUILTIN_WIREGUARD logic
- 919a9807 bsp: add machine settings to support imx8mn-ddr4-evk
- 3fd8b3bc bsp: mfgtool-files: add initial support for imx8mn-ddr4-evk
- 04482ae1 bsp: optee-os-fio: add settings for imx8mn-ddr4-evk
- a7993978 base: u-boot-fio: 2021.04: bump to d5976b62
- e4ecd207 base: kmeta-linux-lmp-5.15.y: bump to 0d5ce625
- 81f0fcea base: kmeta-linux-lmp-5.10.y: bump to ec9e983b
- 9fd10d85 bsp: bluetooth-attach: add imx8mn-evk bluetooth conf file
- c2e2945c bsp: linux-firmware: add firmware for Murata 1MW on imx8mn-evk
- b9b9bc68 bsp: kernel: linux-lmp-fslc-imx: fix bluetooth initialization
- d8e4934d bsp: recipes-core: base-files: add fstab for imx8mn-ddr4-evk
- eafc24b4 bsp: u-boot-base-scr: add boot.cmd for imx8mn-ddr4-evk
- a977484d bsp: u-boot-ostree-scr-fit: add support for imx8mn-ddr4-evk
- 38d82378 bsp: u-boot-fio-mfgtool: add support for imx8mn-ddr4-evk
- fc925d9c bsp: u-boot-fio: add support for imx8mn-ddr4-evk
- e2eeb73d bsp: imx-boot: support spl-only builds with DDR4 firmware
- 40fbbbb7 bsp: imx-atf: imx8mn: enable sip call for secondary boot
- 0a8e890e bsp: imx-atf: imx8mn: implement system_reset2
- 2fc385f8 base: u-boot-fio: imx-2022.04: fix commit hash
- 6fc1cb51 base: u-boot-fio-mfgtool: add version imx-2022.04
- ba54a5a1 base: u-boot-fio: add dependency from gnutls-native
- a02692f3 base: u-boot-fio: add recipe for imx-2022.04
- 39108cce base: u-boot-fio-common: use variable u-boot URL
- 0c40735b base: rc: nerdctl: Add redps on the CNI plugins
- dc6bfd3b base: support: add default btattach.conf to bluetooth-attach service
- cf6f2e3b bsp: lmp-machine-custom: stm32mp1common: set OSTREE_KERNEL_ARGS
- 2d57723a base: rc: nerdctl: Patch docker/cli to set a def conf path
- bfc67505 base: aktualizr: drop musl patches

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>