### PR TITLE
lmp-base: use my own branch for kernel testing

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remote fetch="https://github.com/foundriesio" name="fio"/>
+  <remote fetch="https://github.com/ricardosalveti" name="rsalveti"/>
   <remote fetch="https://github.com/lmp-mirrors" name="lmp-mirrors"/>
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
@@ -9,7 +10,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="089b19ac625976db18e92034e5ece39ea0bea521"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="rsalveti" revision="kernel"/>
   <project name="meta-clang" path="layers/meta-clang" revision="da86f6c3a19d7c0cd1e99810ac2000dd1668ffac"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="acbe74879807fc6f82b62525d32c823899e19036"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 726be680 bsp: linux-lmp-xlnx: update to v5.15.64
- c0fb7adb bsp: linux-lmp-stm32: drop recipe, not used anymore
- 7a9f6ff5 base: linux-lmp-rt: bump to v5.15.55-rt48
- fc00ba3c base: linux-lmp: bump to kernel v5.15.64
- 7afb27a1 bsp: u-boot-xlnx: 2022.01: bump to a84cc076b83
- 97c89915 base: u-boot-fio: 2022.04: bump to d724ad15e21
- f19eb4b0 base: optee-os-fio: 3.18: bump to 6467bb295
- d0096ee8 bsp: stm32mp1common: set ubootenv feature for all stm32mp1
- a52b0e8f bsp: stm32mp15-eval: define LMP_BOOT_FIRMWARE_FILES
- 771fa65d bsp: tf-a-fio: remove false-positive asserts patch
- a0c4a3c4 bsp: u-boot-ostree-scr-fit: boot.cmd with boot firmware updates
- 892df6d4 bsp: u-boot-fio: provide configuration for u-boot-tools
- 3f76236d bsp: tf-a-fio: add support for emmc boot
- 308eb23c bsp: u-boot-fio: stm32mp15-eval: provide u-boot configuration
- d1a2e211 bsp: stm32mp15-eval: build tf-a-fio emmc configuration
- b99177a0 bsp: stm32mp15-eval: provide boot script configuration
- 83ecfc07 bsp: stm32mp1: flashlayout: new layout
- 786897c3 base: u-boot-fio: 2022.04: bump to 53fc827020
- 8d6c1ac3 base: lmp: non-clangable: add tf-a-fio used in stm32mp1
- 0ccb057c base: lmp: non-clangable: add trusted-firmware-a used in am6xxx

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>