### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="089b19ac625976db18e92034e5ece39ea0bea521"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="531bc0be2cdea596b27d038966794bbd7bfce1ac"/>
   <project name="meta-clang" path="layers/meta-clang" revision="da86f6c3a19d7c0cd1e99810ac2000dd1668ffac"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="acbe74879807fc6f82b62525d32c823899e19036"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 531bc0be Revert "base: lmp: non-clangable: add mpfr for x86/x86-64"
- 1937c3f4 Revert "base: clang: backport submited patch to build float128 soft float builtins for x86_64"
- 0abb08c8 base: ostree: as we use static linking fix it with clang
- e3930e02 bsp: linux-lmp-xlnx: update to v5.15.64
- ac4bdcad bsp: linux-lmp-stm32: drop recipe, not used anymore
- 6d962bd9 base: linux-lmp-rt: bump to v5.15.55-rt48
- 9c8f8627 base: linux-lmp: bump to kernel v5.15.64
- 7afb27a1 bsp: u-boot-xlnx: 2022.01: bump to a84cc076b83
- 97c89915 base: u-boot-fio: 2022.04: bump to d724ad15e21
- f19eb4b0 base: optee-os-fio: 3.18: bump to 6467bb295
- d0096ee8 bsp: stm32mp1common: set ubootenv feature for all stm32mp1
- a52b0e8f bsp: stm32mp15-eval: define LMP_BOOT_FIRMWARE_FILES
- 771fa65d bsp: tf-a-fio: remove false-positive asserts patch
- a0c4a3c4 bsp: u-boot-ostree-scr-fit: boot.cmd with boot firmware updates
- 892df6d4 bsp: u-boot-fio: provide configuration for u-boot-tools
- 3f76236d bsp: tf-a-fio: add support for emmc boot
- 308eb23c bsp: u-boot-fio: stm32mp15-eval: provide u-boot configuration
- d1a2e211 bsp: stm32mp15-eval: build tf-a-fio emmc configuration
- b99177a0 bsp: stm32mp15-eval: provide boot script configuration
- 83ecfc07 bsp: stm32mp1: flashlayout: new layout
- 786897c3 base: u-boot-fio: 2022.04: bump to 53fc827020
- 8d6c1ac3 base: lmp: non-clangable: add tf-a-fio used in stm32mp1
- 0ccb057c base: lmp: non-clangable: add trusted-firmware-a used in am6xxx

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>