### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3e4a11a4232ab44e5ea84ffa9778f8b5f43c8d4c"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4fbb4cdd0fd02206d487471195eb2466aa916d4a"/>
   <project name="meta-clang" path="layers/meta-clang" revision="da86f6c3a19d7c0cd1e99810ac2000dd1668ffac"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="acbe74879807fc6f82b62525d32c823899e19036"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 689e544d base: lmp: build with clang toolchain by default
- 5dbfc1dc bsp: u-boot-base-scr: load uEnv.txt from boot
- 82444892 base: u-boot-base-sct: deplot uEnv.txt to boot dir
- 5839dfa2 bsp: stm32mp15-eval: install boot artifacts with extra depends
- e01e5fde base: u-boot: RPROVIDES for u-boot script
- f7e6945a base: u-boot-base-scr: install boot.scr and uEnv.txt
- 8fd8488c base: optee-os-fio: 3.18: bump to 939fb9c74
- 44f7511d base: initramfs-ostree-lmp-recovery: depend on u-boot-default-env instead
- 40954352 base: initramfs-ostree-lmp-recovery: drop more fstypes image formats
- 6af90295 bsp: tf-a-fio: add correct fix for assert issue in TF-A
- c553387d bsp: stm32mp15-eval: include kernel, dtb and boot scripts in rootfs
- 37640c18 bsp: stm32mp15-eval: support ext4 image fstype for non-sota builds
- ca1c72d1 bsp: stm32mp: flashlayouts: make rootfs partition bootable
- fc7b16f0 bsp: u-boot-base-scr: deploy boot script to rootfs
- 9fedf181 base: lmp-image-common: create /etc/sudoers.d
- 464ac122 bsp: u-boot-fio: stm32mp15-eval: correct u-boot-env offset
- fd0854d3 bsp: u-boot-base-scr: stm32mp15-eval: add boot script

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>