### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c5a3a5711a8d1e194c0b7c53f0d48faa7085b27a"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="747cd8ef90d2da1fae7902330aa1af46f70a2fa6"/>
   <project name="meta-clang" path="layers/meta-clang" revision="3d63d0fd6296e23c7cbbae431e20aa3985ec69dd"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="05dcac98473402d87e0af73bbc2c5a6a840abe93"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 747cd8ef base: kmeta-linux-lmp-5.15.y: bump to 83b1b4b5
- 01b798b0 bsp: device-tree: kv260: enable display
- a9e7cae6 bsp: device-tree: kv260: enable pwm fan for fancontrol
- 9fc08452 bsp: lmsensors: enable fancontrol by default on kv260
- 591daf58 bsp: lmsensors-config: add fancontrol config for kv260
- 7aeca314 bsp: zynqmp-lmp: use kernel args from latest xilinx BSP

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>