### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9615341dd988052b7a49cb312685505426334e0c"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="b6de3a93e60c771cf34085907b3d6084101a5bbf"/>
   <project name="meta-clang" path="layers/meta-clang" revision="3d63d0fd6296e23c7cbbae431e20aa3985ec69dd"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="05dcac98473402d87e0af73bbc2c5a6a840abe93"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- b6de3a93 bsp: imx-atf: refresh patch with incorrect definition
- 0b950b9e bsp: u-boot-fio: imx8mn-ddr4-evk-sec: add u-boot configs
- 99779c4f bsp: mfgtool-files: imx8mn-ddr4-evk-sec: add fuse and close scripts
- 58b97be9 bsp: optee-os-fio: add settings for imx8mn-ddr4-evk-sec
- 84bea1d5 bsp: conf: add imx8mn-ddr4-evk-sec machine configuration
- 44f4b289 bsp: imx-atf: update based on lf-5.15.32-2.0.0
- a8dc1f52 base: lmp-xwayland: drop meta-freescale gtk+ from bbmask
- 78be26d1 bsp: imx-boot: refresh patches on top of lf-5.15.32_2.0.0
- 9f14501c bsp: imx-boot: drop patch removal
- a2f5d17e optee-os-fio-se05x: support SE050E
- c86f9e22 lmp-staging: serialize do_compile of heavy tasks
- 0e0bf9ff lmp-staging: get the PN on startup as it is commom used

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>