### PR TITLE
Meta-lmp and latest tegra related updates

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="de2cf0a57e592be32a59acf12fd9ecad519e9ee2"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="b83963a28779805581ae2e7ffcc47373bc859a2d"/>
   <project name="meta-clang" path="layers/meta-clang" revision="3d63d0fd6296e23c7cbbae431e20aa3985ec69dd"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="05dcac98473402d87e0af73bbc2c5a6a840abe93"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -14,7 +14,7 @@
   <project name="meta-yocto" path="layers/meta-yocto" revision="ca9c465e37b693ab768ee8e21a929d1c18956e98"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="bac5f428e9948cbc373f2ae891c0c9c8fa0fc45d"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="1ae60d32307c304304ebed02008e6866d31c27c9"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="47d7eab38637e56ea06f1814dae2f7ba272d40e1"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="773dc04614a4b03c1572cf4b778649c506051176"/>
   <project name="meta-ti" path="layers/meta-ti" revision="2124e7ecd88d1aded320e86da62785c3ab171b27"/>
 </manifest>


### PR DESCRIPTION
Bring meta-lmp to the latest and update mete-tegra for allowing building OP-TEE from source.