### PR TITLE
Bump meta-freescale and meta-freescale-3rdparty to the latest in Kirkstone

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -7,7 +7,7 @@
 
   <project name="meta-arm" path="layers/meta-arm" revision="bafd1d013c2470bcec123ba4eb8232ab879b2660"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="3747641f1e71d8e4edd5b587b49d09dc2d243942"/>
-  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="07c9d8e205caa3a41844d7f9086bdc88cfdff7a7"/>
+  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="5977197340c7a7db17fe3e02a4e014ad997565ae"/>
   <project name="meta-intel" path="layers/meta-intel" revision="01ad1a73aaab49d377d14bad8a7dec48f86cba83"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="dacad9302a92b0b7edf8546cdcad1f8ef753e462"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="00c2494b66b8fa2c0fc2008fa802a2adbeed966e"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="bafd1d013c2470bcec123ba4eb8232ab879b2660"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="7d7d4a46e64f9c4fa4f257ac0f670e23ba746520"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="3747641f1e71d8e4edd5b587b49d09dc2d243942"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="07c9d8e205caa3a41844d7f9086bdc88cfdff7a7"/>
   <project name="meta-intel" path="layers/meta-intel" revision="01ad1a73aaab49d377d14bad8a7dec48f86cba83"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="dacad9302a92b0b7edf8546cdcad1f8ef753e462"/>


### PR DESCRIPTION
It replaces the commit ids used before as they were pointing to master branch (from meta-freescale*)

Now it points to kirkstone branch.

They are similar, but different commit ids.