### PR TITLE
conf/local.conf: adds TOPDIR to vardepsexclude when they are used

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -59,6 +59,7 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-lmp"
 # The default key provided should only be used for development purposes.
 # To create a custom signing key, follow the instructions on kernel documentation.
 MODSIGN_KEY_DIR ?= "${TOPDIR}/conf/keys"
+MODSIGN_KEY_DIR[vardepsexclude] += "TOPDIR"
 
 #
 # SPL / U-Boot proper signing support
@@ -70,6 +71,7 @@ UBOOT_SPL_SIGN_KEYNAME ?= "spldev"
 #
 # Supported key type: RSA 2048
 UBOOT_SIGN_KEYDIR ??= "${TOPDIR}/conf/keys"
+UBOOT_SIGN_KEYDIR[vardepsexclude] += "TOPDIR"
 UBOOT_SIGN_KEYNAME ?= "ubootdev"
 #UBOOT_SIGN_ENABLE ?= "1"
 
@@ -81,12 +83,14 @@ UBOOT_SIGN_KEYNAME ?= "ubootdev"
 # custom signing key just generate a custom RSA 2048 key (PEM format) and
 # set via the OPTEE_TA_SIGN_KEY variable.
 OPTEE_TA_SIGN_KEY ??= "${TOPDIR}/conf/keys/opteedev.key"
+OPTEE_TA_SIGN_KEY[vardepsexclude] += "TOPDIR"
 
 #
 # TF-A Trusted Boot
 #
 # Supported key type: ECDSA (prime256v1)
 TF_A_SIGN_KEY_PATH ??= "${TOPDIR}/conf/keys/tf-a/privkey_ec_prime256v1.pem"
+TF_A_SIGN_KEY_PATH[vardepsexclude] += "TOPDIR"
 #TF_A_SIGN_ENABLE ?= "1"
 
 #
@@ -94,4 +98,5 @@ TF_A_SIGN_KEY_PATH ??= "${TOPDIR}/conf/keys/tf-a/privkey_ec_prime256v1.pem"
 #
 # Folder for UEFI keys and certificates
 UEFI_SIGN_KEYDIR ??= "${TOPDIR}/conf/keys/uefi"
+UEFI_SIGN_KEYDIR[vardepsexclude] += "TOPDIR"
 #UEFI_SIGN_ENABLE ?= "1"


### PR DESCRIPTION
Some of the variables in local.conf uses the $TOPDIR in the path and this will break the usage of the sstate cache when we change the build directory.
This fix will improve the sstate cache reuse for many tasks and will make it resileient to builddir changes.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>