### PR TITLE
Update meta-freescale: atf, firmware, mkimage, optee

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="bafd1d013c2470bcec123ba4eb8232ab879b2660"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="3747641f1e71d8e4edd5b587b49d09dc2d243942"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="d388644623ca60eeb25cc2b38986f155819dc756"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="5977197340c7a7db17fe3e02a4e014ad997565ae"/>
   <project name="meta-intel" path="layers/meta-intel" revision="94837c7212b5be5dc73310d91d427e8616ef84f7"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="dacad9302a92b0b7edf8546cdcad1f8ef753e462"/>


### PR DESCRIPTION
Tested on:
- imx8mm

Relevant changes:
- d3886446 Merge pull request #1286 from MrCry0/backport-1283-to-kirkstone
- 0b53460b Merge pull request #1285 from Freescale/backport-1284-to-kirkstone
- 7bc92291 imx-mkimage: Update lf-5.15.32-2.0.0 to lf-5.15.52-2.1.0
- 0f4d3495 imx-lib: Update lf-5.15.32-2.0.0 to lf-5.15.52-2.1.0
- c9d80965 imx-atf: Update lf-5.15.32-2.0.0 to lf-5.15.52-2.1.0
- 23b0b827 firmware-imx: Upgrade 8.16 -> 8.17
- d2cf90c4 optee-test: Update lf-5.15.32_2.0.0 -> lf-5.15.52_2.1.0
- 91bddd14 optee-client: Update lf-5.15.32_2.0.0 -> lf-5.15.52_2.1.0
- 71bcca68 optee-os: Update lf-5.15.32_2.0.0 -> lf-5.15.52_2.1.0

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>