### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c27d752edae0af8bf98da5d2c47b9628d09949b3"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="6b3d28a6628c49aa5ab1d05ab35cfdc4b0fc4e34"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="744a4b6eda88b9a9ca1cf0df6e18be384d9054e3"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 6b3d28a6 base: u-boot-fio: imx-2022.04: bump to 92012fed804
- c0e52006 base: optee-os-fio: 3.18: bump to f2159b5a0
- fe6cf428 lmp-staging: fix network var flag usage
- fad63bfe base: optee-os-fio: 3.18: bump to fcf11c1f0
- 0d62485f optee-os-fio-se05x: support SE050F
- 8bd89113 bsp: dynamic-layers: xilinx: device-tree: slew settings for kv26
- 403812e1 bsp: dynamic-layers: device-tree: fix reset-gpios configuration for usb
- 5a8e04a2 bsp: machine: zynqmp-lmp: kv26: autoload usb5744 module
- 9aa9b4ce base: containers: log container name instead of container id
- ade232a7 lmp-base: fio-se05x-cli: support multiple tokens
- e73e4ba7 base: images: debug: install dtc package
- 22783745 base: layer.conf: exclude os-release in the siggen as it is abisafe

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>