### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="6b3d28a6628c49aa5ab1d05ab35cfdc4b0fc4e34"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9cedb6217b9ad9254013144f1f2fdf7b425735b7"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="744a4b6eda88b9a9ca1cf0df6e18be384d9054e3"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 9cedb621 lmp-base: fio-se05x-cli: bump version
- 0e9cc00b bsp: u-boot-ostree-scr-fit: explicitly specify that offsets are in hex
- d8e39768 base: u-boot-ostree-scr-fit: print fiovb.is_secondary_boot
- b9dd994d base: mcumgr: bump 5c56bd
- 0b58ce13 base: mcumgr: relay only on go that uses goarch underline
- 14060255 base: non-clangable: add mcumgr
- 105227db base: images: move i2c-tools to feature-debug
- a7ef4674 base: lmp-base: include development debug tools

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>