### PR TITLE
Setup environment internal: enable buildstats and buildhistory options

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -255,6 +255,8 @@ SDKMACHINE ?= "${SDKMACHINE}"
 # Extra options that can be changed by the user
 INHERIT += "rm_work"
 INHERIT += "buildstats buildstats-summary"
+INHERIT += "buildhistory"
+BUILDHISTORY_COMMIT = "1"
 EOF
 
 if [ ! -e conf/site.conf ]; then

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -254,6 +254,7 @@ SDKMACHINE ?= "${SDKMACHINE}"
 
 # Extra options that can be changed by the user
 INHERIT += "rm_work"
+INHERIT += "buildstats buildstats-summary"
 EOF
 
 if [ ! -e conf/site.conf ]; then


### PR DESCRIPTION
- **buildstats** option is only enabled on the CI build but it is very useful in local builds as well to check sstate-cache usage.

- **buildhistory** it has been enabled on LmP distro meta-lmp-base but this is a better place to do it as this is a build options and not a disto options.