### PR TITLE
setup-environment-internal: adds HTTPS sstate mirror

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -247,10 +247,19 @@ ln -sf "${MANIFESTS}" "${OEROOT}"/layers/
 
 DISTRO_DIRNAME=$(echo "${DISTRO}" | sed 's#[.-]#_#g')
 
+LMP_VER=$(git --git-dir ${MANIFESTS}/.git describe HEAD --tags --abbrev=0)
+if [ -v LMP_VER_DEV ]; then
+    # to use the development version of the cache the user need to define the LMP_VER_DEV env
+    LMP_VER=$(( $LMP_VER + 1 ))
+fi
+
 cat > conf/auto.conf <<EOF
 DISTRO ?= "${DISTRO}"
 MACHINE ?= "${MACHINE}"
 SDKMACHINE ?= "${SDKMACHINE}"
+
+# Use public state cache mirror if no other is defined
+SSTATE_MIRRORS ??= "file://.* https://storage.googleapis.com/lmp-cache/v$LMP_VER-sstate-cache/PATH"
 
 # Extra options that can be changed by the user
 INHERIT += "rm_work"


### PR DESCRIPTION
- Use a weak assing so it will be used if no one exist.
- This improves a lot the build time of the public LmP.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>