### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9cedb6217b9ad9254013144f1f2fdf7b425735b7"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="a4a5737e51aabddfce0eb84843d138d44b2d5227"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="744a4b6eda88b9a9ca1cf0df6e18be384d9054e3"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- a4a5737e base: kmeta-linux-lmp-5.15.y: bump to 9ec0e7d2
- 807ff4fc base: mfgtool-files: update UUU 1.4.193 -> 1.4.243
- f400706d bsp: add linux-lmp-fslc-imx-rt
- 1c2eb4af base: kmeta-linux-lmp-5.15.y: bump to 852f54a8
- 5bfeef4c lmp-base: fio-se05x-cli: bump version
- f0821c4a base: u-boot-ostree-scr-fit: refactor boot-common include
- a78ae7f4 os-release: bypass the allarch_package_arch_handler
- 549d4963 bsp: linux-lmp-xlnx: update to v5.15.74
- 9aa69477 base: linux-lmp-rt: bump to v5.15.76-rt53
- c9853b12 base: linux-lmp: bump to kernel v5.15.79
- 514a661a bsp: linux-lmp-fslc-imx: update to v5.15.77

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>