### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="a4a5737e51aabddfce0eb84843d138d44b2d5227"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f34142a8b150c1a0286ff4dbc30060641090c5f0"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="744a4b6eda88b9a9ca1cf0df6e18be384d9054e3"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- f34142a8 bsp: lmp-machine-custom: imx8mq-evk: rrecommend bluetooth-attach
- e7b27980 bsp: bluetooth-attach: add imx8mq-evk bluetooth conf file
- 06e22c95 bsp: u-boot-fio-mfgtool: secondary boot cmd for imx8qm-mek
- 368ac23c bsp: lmp-machine-custom: mx8mq: change kernel entrypoint to be aligned
- 5ac6c8f8 bsp: mx8mq: switch kernel to fslc-imx 5.15
- 52ce5b51 bsp: u-boot-fio-mfgtool: imx8mq-evk: switch u-boot to imx-2022.04
- 740ebb48 bsp: u-boot-fio: imx8mq-evk: switch u-boot to imx-2022.04

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>