### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f34142a8b150c1a0286ff4dbc30060641090c5f0"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="e3e1596c82f778b561d5d315c19d03d6733411d5"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="744a4b6eda88b9a9ca1cf0df6e18be384d9054e3"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- e3e1596c base: nerdctl: update to v0.22.2
- 4f74698c base: docker-compose: update to v2.10.2
- 70a6dfa9 base: docker-ce: update to 20.10.21
- 7ac286ec base: containerd-opencontainers: update to 1.6.9
- 5b04ba65 base: runc-opencontainers: update to 1.1.4
- 43449160 base: non-clangable: add runc-opencontainers
- 3d0378c5 base: optee-os-fio: deploy build configuration
- bbf43b82 bsp: imx8mm-lpddr4-evk: lmp-ebbr: disable options due size

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>