### PR TITLE
kirstone alignment for stable v89

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3c5b4464363e250c29ffc5e46db5af9dad2b7278"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="744a4b6eda88b9a9ca1cf0df6e18be384d9054e3"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="50d4a8d2a983a68383ef1ffec2c8e21adf0c1a79"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>
   <project name="meta-updater" path="layers/meta-updater" revision="c74a06710818bbac3079eb1f3b370625ea1ba494"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="9a487c1851aa2021cf24f951957e22fd429c8025"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="ac576d6fad6bba0cfea931883f25264ea83747ca"/>
+  <project name="bitbake" revision="72a3afd99e8b785cb2a2f687e71a58e08cdd9c74"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>
   <project name="meta-updater" path="layers/meta-updater" revision="c74a06710818bbac3079eb1f3b370625ea1ba494"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="8c5f038cb92fa4b02246d2d1479a003eecf5fe93"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="555fd2848b970fd38c20651b5e98cabb7f31287c"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="da2c64b3158c58eb0a484d3acbdf0419df2d34e8"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -14,6 +14,6 @@
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="744a4b6eda88b9a9ca1cf0df6e18be384d9054e3"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>
   <project name="meta-updater" path="layers/meta-updater" revision="c74a06710818bbac3079eb1f3b370625ea1ba494"/>
-  <project name="meta-virtualization" path="layers/meta-virtualization" revision="8c5f038cb92fa4b02246d2d1479a003eecf5fe93"/>
+  <project name="meta-virtualization" path="layers/meta-virtualization" revision="9a487c1851aa2021cf24f951957e22fd429c8025"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="da2c64b3158c58eb0a484d3acbdf0419df2d34e8"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3c5b4464363e250c29ffc5e46db5af9dad2b7278"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f85e0e70425488e2d4ffe52e9d0ff8c60ff6d118"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="50d4a8d2a983a68383ef1ffec2c8e21adf0c1a79"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -7,7 +7,7 @@
 
   <project name="meta-arm" path="layers/meta-arm" revision="67578fcfcd8ee8efcaef67ed7db1dfd55105872e"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="04f1419518d41db95f3f33d1d82c1d00853715ff"/>
-  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="5977197340c7a7db17fe3e02a4e014ad997565ae"/>
+  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="e1ec96f0b1d89adab9ec1f224e7d6dcb0ef565c0"/>
   <project name="meta-intel" path="layers/meta-intel" revision="f529e0594a784546926e89ce8e78385e00d0b0a9"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="dacad9302a92b0b7edf8546cdcad1f8ef753e462"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="00c2494b66b8fa2c0fc2008fa802a2adbeed966e"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -12,7 +12,7 @@
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="dacad9302a92b0b7edf8546cdcad1f8ef753e462"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="00c2494b66b8fa2c0fc2008fa802a2adbeed966e"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="8f216dca2fda2c8862f81dacdcf11df3118b31b7"/>
-  <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="bac5f428e9948cbc373f2ae891c0c9c8fa0fc45d"/>
+  <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="f8d8efab12040712df32436643621b2756de1f76"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="9d58efcfad33a0496b2099e01111c4c937bf3287"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="773dc04614a4b03c1572cf4b778649c506051176"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -14,7 +14,7 @@
   <project name="meta-yocto" path="layers/meta-yocto" revision="8f216dca2fda2c8862f81dacdcf11df3118b31b7"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="bac5f428e9948cbc373f2ae891c0c9c8fa0fc45d"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="67a6186024fa341943c9d3af1ec037e2f4c7ddb2"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="9d58efcfad33a0496b2099e01111c4c937bf3287"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="773dc04614a4b03c1572cf4b778649c506051176"/>
   <project name="meta-ti" path="layers/meta-ti" revision="2124e7ecd88d1aded320e86da62785c3ab171b27"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="meta-arm" path="layers/meta-arm" revision="bafd1d013c2470bcec123ba4eb8232ab879b2660"/>
+  <project name="meta-arm" path="layers/meta-arm" revision="67578fcfcd8ee8efcaef67ed7db1dfd55105872e"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="04f1419518d41db95f3f33d1d82c1d00853715ff"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="5977197340c7a7db17fe3e02a4e014ad997565ae"/>
   <project name="meta-intel" path="layers/meta-intel" revision="94837c7212b5be5dc73310d91d427e8616ef84f7"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -8,7 +8,7 @@
   <project name="meta-arm" path="layers/meta-arm" revision="67578fcfcd8ee8efcaef67ed7db1dfd55105872e"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="04f1419518d41db95f3f33d1d82c1d00853715ff"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="5977197340c7a7db17fe3e02a4e014ad997565ae"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="94837c7212b5be5dc73310d91d427e8616ef84f7"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="f529e0594a784546926e89ce8e78385e00d0b0a9"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="dacad9302a92b0b7edf8546cdcad1f8ef753e462"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="00c2494b66b8fa2c0fc2008fa802a2adbeed966e"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="8f216dca2fda2c8862f81dacdcf11df3118b31b7"/>


### PR DESCRIPTION
All layers updated to track kirstone with the following exceptions:

- **stm32mp**: meta-st-stm32mp
- **xilinx**: meta-xilinx / meta-xilinx-tools
- **ti**: meta-ti
- **imx**: meta-freescale