### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3c5b4464363e250c29ffc5e46db5af9dad2b7278"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="80b73b37c6ceeef73e12f0143b0e7e31d7753754"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="744a4b6eda88b9a9ca1cf0df6e18be384d9054e3"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
```
Relevant changes:
- 80b73b37 base: u-boot-fio: imx-2022.04: bump to 7bd9d0a8fc
- b306fe7e bsp: u-boot-fio: imx8: fix bootscr address
- 3c5b4464 base/bsp: nxp: use latest NXP BSP by default
- 9dd057d5 bsp: linux-lmp-dev-mfgtool: imx8mq-evk: fix build with 5.15
- e1193b1b base: u-boot-fio: 2022.04: bump to 3b47abb216
- f066bdec bsp: u-boot-fio-mfgtool: extend stm32mp15-eval malloc pool before reloc
- 0d901655 bsp: u-boot-fio: extend stm32mp15-disco malloc pool before reloc
- 029d2a4e bsp: u-boot-fio: extend stm32mp15-eval malloc pool before reloc
- d0281687 bsp: optee-os-fio-mfgtool: add support for se050 on stm32mp15-eval
- 71cdb8c8 bsp: optee-os-fio-mfgtool: add support for se050 on stm32mp15-disco
- d1e1c612 bsp: initramfs-ostree-lmp-recovery: enable tee-supplicant
- c2829cf0 bsp: stm32mp: introduce stm32-mfgtool-files dynamic recipe
- 4802f616 bsp: machine: lmp-mfgtool: add support for stm32mp1common
- 42cbf8fa bsp: machine: support stm32mp15-eval-sec target
- 80b73b37 base: u-boot-fio: imx-2022.04: bump to 7bd9d0a8fc
- b306fe7e bsp: u-boot-fio: imx8: fix bootscr address

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```