### PR TITLE
Stable meta-freescale updates

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="67578fcfcd8ee8efcaef67ed7db1dfd55105872e"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="04f1419518d41db95f3f33d1d82c1d00853715ff"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="5d5d2822c3381b3a337b267ce1ec92c87e1b87a3"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="e1ec96f0b1d89adab9ec1f224e7d6dcb0ef565c0"/>
   <project name="meta-intel" path="layers/meta-intel" revision="f529e0594a784546926e89ce8e78385e00d0b0a9"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="dacad9302a92b0b7edf8546cdcad1f8ef753e462"/>


### PR DESCRIPTION
Relevant changes:
- 5d5d2822 Merge pull request #1317 from Freescale/backport-1316-to-kirkstone
- 9cbe8bdd imx-base.inc: Add virtual/opencl-icd to MACHINE_SOCARCH_FILTER
- f22c5134 imx-base.inc: Fix MACHINE_SOCARCH_FILTER for OpenCL
- 0483bf2a Merge pull request #1315 from Freescale/backport-1314-to-kirkstone
- f23428c2 kernel-module-imx-gpu-viv: fix version in recipe file name
- 510dbbe5 imx-seco-libs: upgrade from lf-5.15.5_1.0.0 to lf-5.15.52-2.1.0
- 351f0f97 imx-seco: upgrade from 3.8.6 to 5.8.7.1
- 0ea4beeb imx-sc-firmware: upgrade from 1.13.0 to 1.14.0
- 7a27adb4 firmware-sof-imx: upgrade from 1.9.0-1 to 2.2.0
- cf3221cd imx-boot: Create missing build directories
- eefa361a Merge pull request #1313 from Freescale/backport-1311-to-kirkstone
- c807d7db imx-boot-container: add copy of soc-specific firmware

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>