### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="f85e0e70425488e2d4ffe52e9d0ff8c60ff6d118"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="2e76f1c9aad281a925625a5750c87aad0c9c9044"/>
   <project name="meta-clang" path="layers/meta-clang" revision="013b5eeb580bc13b156aaf77d0c1175f75b89671"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="50d4a8d2a983a68383ef1ffec2c8e21adf0c1a79"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 0892fae9 bsp: u-boot-fio: disable rpmb and fiovb for non-sec machines
- 89157c3f bsp: optee-os-fio: imx6ulevk: disable caam crypto driver
- cdfc6431 bsp: u-boot-base-scr: imx6ullevk: apply optee overlay
- 77aea870 bsp: u-boot-base-scr: imx6ulevk: apply optee overlay
- 2974a6ae base: kernel: linux-lmp: enable generation of FDT symbols
- d8ccc239 base: kmeta-linux-lmp-5.15.y: bump to 9ad1611
- 04ac5af8 base: u-boot-ostree-scr-fit: move boot-common-imx to bsp
- 9e042f9b bsp: u-boot-fio: stm32mp15-eval-sec: add lmp.cfg
- ee715ee0 bsp: u-boot-fio: stm32mp15-eval: disable CONFIG_ENV_IS_NOWHERE
- 0c93d0f6 bsp: dynamic-layers: u-boot-xlnx: store env on SD
- 2a555217 bsp: dynamic-layers: u-boot-xlnx: correct CONFIG_ENV_IS_NOWHERE option
- 4f19b24a bsp: u-boot-fio: imx8qm-mek: introduce secure lmp.cfg
- 02d1863f bsp: u-boot-fio: apalis-imx8: introduce secure lmp.cfg

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>