### PR TITLE
Add support for imx8mn-lpddr4-evk/sec

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -2,6 +2,7 @@
 <manifest>
   <remote fetch="https://github.com/foundriesio" name="fio"/>
   <remote fetch="https://github.com/lmp-mirrors" name="lmp-mirrors"/>
+  <remote fetch="https://github.com/ricardosalveti" name="ricardosalveti"/>
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
@@ -9,7 +10,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1a2f586cecb3e15b19575d41dcfc6ee037897b7c"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="ricardosalveti" revision="mx8mn-lpddr"/>
   <project name="meta-clang" path="layers/meta-clang" revision="63a6101e27af6436eca646d0c887e4c4ed0760ef"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="50d4a8d2a983a68383ef1ffec2c8e21adf0c1a79"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- bsp: lmp-machine-custom: make IMXBOOT_TARGETS hw specific for 8mn
- bsp: conf: add imx8mn-lpddr4-evk-sec machine configuration
- bsp: u-boot-fio/scr/base-files: add support for imx8mn-lpddr4-evk/sec
- bsp: mfgtool-files: add support for imx8mn-lpddr4-evk/sec
- bsp: optee-os-fio: add support for imx8mn-lpddr4-evk
- bsp: linux-lmp-fslc-imx: change imx8mn patch override to mx8mn-nxp-bsp
- bsp: lmp-machine-custom: add support for imx8mn-lpddr4-evk

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>