### PR TITLE
lmp-bsp: update meta-ti layer

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -16,5 +16,5 @@
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="03ff1b9911475a16fd56ac84274c4813c383140e"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="df4da8dd068b4c96eee2a82a0f96946126db026a"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="2124e7ecd88d1aded320e86da62785c3ab171b27"/>
+  <project name="meta-ti" path="layers/meta-ti" revision="2a5a0339d5bd28d6f6aedaf02a6aaa9b73a248e4"/>
 </manifest>


### PR DESCRIPTION
Relevant changes:
- 2a5a0339 ti-sci-fw: make dependency on meta-ti-extras soft
- 6982506b conf/machine/omapl138: correct few of the machine settings
- d59d441e optee: make bbappends version-specific
- 48841468 cmem-mod: Remove CMEM kernel module
- 1c52b0f1 optee-os: Upgrade to upstream 3.19.0
- 52820f87 ti-img-rogue-driver: Bump the source revision
- 2898d7f9 ti-sci-fw: use getVar() to check if TI_SECURE_DEV_PKG_K3 is defined
- 5d9c2a47 ti-k3-secdev: include ti-paths.inc
- 7a35057d linux-ti-staging: update to the latest
- fbab56f6 u-boot-ti-staging: update to the latest
- 6f4f33ae ti-linux-fw: update to the latest
- 35ffdbeb cnm-wave-fw: update firmware name to wave521c_k3_codec_fw.bin
- 48b7eb8f optee-os: Enable TRNG driver as OP-TEE support is added
- c08fc953 conf: machine: j721s2: Add OP-TEE flavour
- bfc50762 conf: machine: j784s4: Add OP-TEE flavour
- 1e0b4ec1 optee-os: Update SRCREV for OP-TEE TRNG in J784S4
- 6a40ad5c j721s2 and j784s4: Correct serial console device
- 49c86278 ti-img-rogue-driver: drop local patch as upstream is now fixed
- e792496d ti-img-rogue-*: Bump the graphics recipes
- 2f49751d trusted-firmware-a: Update to latest upstream master
- 72009bf2 machine: Add j784s4-evm configuration.
- df577a39 ti-img-rogue-driver: Fix git SRC_URI
- 3ced9c2f ipc: ti-rpmsg-char: Update library to 0.5.1
- 149ad8af ti-rtos-firmware: j721s2-hs-evm: add secure firmware images
- 3d1cf253 ti-rtos-firmware: j7200-hs-evm: add secure firmware images
- bc80b602 ti-rtos-firmware: j721e-hs-evm: add secure firmware images
- f10cb843 linux-ti-mainline: unbreak devtool
- ad6ce59b conf: machine: am64xx: Move multi-config targets into base SoC include
- 1df14b1b conf: machine: am64xx-evm: Switch to SR2.0 HS-FS build by default
- 84fbe8f6 cadence-mhdp-fw: Add dependency for j721s2
- 0e01313f ti-sci-fw: Use d.getVar() in DEPENDS expression
- b6a3803c optee-os: Lower log level for AM62x
- a5f0beec optee-os: Upgrade to upstream 3.18.0
- 50130b9b machine: add am62xx-lp-evm configuration
- ef962d28 conf: machine: am64xx-evm: Update default HS names
- 737f3583 all: Stop using git://git.ti.com
- c60b432d conf: machine: am64xx-evm: Make HS-SE the default
- 128a254e u-boot-ti-staging: Update to the latest ti-u-boot-2021.01
- eda6651d ti-sci-fw: Use ti-k3-secdev if TI_SECURE_DEV_PKG_K3 is not defined
- 6f715d91 recipies-ti: Add TI K3 Security Development Package
- 7e9cecaa trusted-firmware-a: upgrade to v2.7
- d3e20cd2 ti-sci-fw: Add am65xx-evm-k3r5-sr2 to combined R5 boot list
- ca2f4028 k3: also inherit kernel-fitimage class for FIT image generation
- 6431130f conf: machine: k3: Add fitImage to the default kernel image types
- 9d6f9556 conf: machine: am64xx-hs-evm: Add extra machine to build GP SYSFW
- 500e34c0 ti-sci-fw: Only deploy the raw SYSFW images for one machine target
- b22bef83 conf: machine: Move K3 TI_SECURE_DEV_PKG definition to common include
- 2817e00a ti-sci-fw: Only install and deploy combined boot symlink when set
- 36ed77a4 ti-sci-fw: Make combined R5 boot the default
- 8287c4af ti-sci-fw: Use SYSFW_TIBOOT3 to point to the SYSFW image
- e9738ac4 ti-sci-fw: Deploy all SYSFW firmware types
- 037dc07e ti-sci-fw: Use new SOC_TYPE and SYSFW_DIR to simplify recipe
- b29342ab machine: k3r5: Make combined R5 boot the default
- 901a72a2 linux-ti-next: add recipe for building linux-next
- 7258f62d u-boot-ti-mainline: update to the latest 2022.10
- bb9bac68 u-boot: drop 2020.01
- 34f129fb linux: drop 5.4 kernel
- 5eb1a669 layers: Add langdale to LAYERSERIES_COMPAT
- 2b11afa8 prueth-fw: Deploy for AM64xx based on SoC not EVM
- 47d21266 trusted-firmware-a: Allow build to continue without TI_SECURE_DEV_PKG set
- e1f119c9 optee-os: Allow build to continue without TI_SECURE_DEV_PKG set
- c64c2ad4 u-boot-ti: Do not prepend output files with DEPLOYDIR
- 8a81c48d conf: machine: Make multi-certificate image the default
- 77753a13 ti-linux-fw: Bump to 08.04.01.001 release
- 6c9c0b22 linux-ti-staging-rt: Bump to 08.04.01.001 release
- bc268a11 linux-ti-staging: Bump to 08.04.01.001 release
- c5adf7f6 u-boot-ti-staging: CI/CD Auto-Merger: cicd.2022.07.30.15:19:12
- 9d15def4 ti-linux-fw: Create K3_IMAGE_GEN_BRANCH variable
- 59e2bfd7 cadence-mhdp-fw: Lock firmware to j721e
- fec5a9ff linux-ti-staging-rt: Bump to 08.04.00.005 release
- 555fdfce linux-ti-staging: Bump to 08.04.00.005 release
- 8bfb4136 u-boot-ti-staging: Bump to 08.04.00.005 release
- c36d687a kernel u-boot: Fix formulation of LOCALVERSION
- 5eca63d1 j7200-hs-evm-k3r5: Move J7200 HS evm support to PG2.0
- cc987c6f k3conf: update SRCREV to add j721S2 fixes
- fac7b496 j721e-hs-evm-k3r5: do not create generic sysfw.itb symlink
- 6686c2f6 ti-img-encode-decode: Lock test app to j7-evm
- 85f42b95 conf: am43: avoid missing dtb files for linux-ti-mainline
- 3dc7e20b conf: am57xx-evm: avoid missing dtb files for linux-ti-mainline
- 386e9688 conf: dra7xx-evm: avoid missing dtb files for linux-ti-mainline
- 0c9b989e linux-ti-staging-rt: Bump to 08.04.00.004 release
- 2ca9237b linux-ti-staging: Bump to 08.04.00.004 release
- 9e224978 u-boot-ti-staging: Bump to 08.04.00.004 release
- 2954a335 conf: machine: j721s2: add new dtb for GESI
- e20a5200 linux-ti-staging: Unblock SA2UL for AM64x and J7200 HS devices
- 8a05ea29 optee-os: Use software RNG on AM62x and J721s2
- 3e05a20a linux-ti-staging-rt: Bump to 08.04.00.003 release
- a00773c9 linux-ti-staging: Bump to 08.04.00.003 release
- 6a608220 u-boot-ti-staging: Bump to 08.04.00.003 release
- 6e6c2b71 linux-ti-staging: CI/CD Auto-Merger: cicd.2022.06.28.12:11:17
- b4db4345 linux-ti-staging-rt: CI/CD Auto-Merger: cicd.2022.06.28.12:11:17
- 897c6749 u-boot-ti-staging: CI/CD Auto-Merger: cicd.2022.06.28.12:11:17
- a978baef conf: machine: wic: Fix j721s2-hs-evm image boot partition
- b49e78d0 ti-linux-fw: Bump to 08.04.00.002 release
- edc6cc78 linux-ti-staging-rt: Bump to 08.04.00.002 release
- 406941d6 linux-ti-staging: Bump to 08.04.00.002 release
- 1ef9eed8 u-boot-ti-staging: Bump to 08.04.00.002 release
- 087da890 conf: machine: wic: Fix HS image boot partition
- ddff6686 k3conf: update SRCREV to add J721S2 support
- 1899bc04 optee: Upgrade to upstream 3.17.0
- 761d5c18 trusted-firmware-a: Update to latest upstream master
- a4037a50 ti-linux-fw: Bump to 08.04.00.001 release
- 4f1ed197 linux-ti-staging-rt: Bump to 08.04.00.001 release
- 7eeaec40 linux-ti-staging: Bump to 08.04.00.001 release
- 19b0ef1d u-boot-ti-staging: Bump to 08.04.00.001 release
- f8558a36 u-boot: Bump to verison that supports j721s2-hs-evm
- cb5890b9 cnm-wave-fw: mark also compatible with j721s2 HS
- 3a1e3bfe j721s2-hs: changes to support new hs platform
- b3822e7b ti-rtos-firmware: Add j721s2 hs support
- 77fc98c7 conf: machine: Add j721s2 hs platform
- 1da21eee conf: machine: am64xx: Add missing dtbo
- 0aad7566 ti-linux-fw: Bump to 08.03.00.005 release
- 4533610d linux-ti-staging-rt: Bump to 08.03.00.005 release
- 279f7261 linux-ti-staging: Bump to 08.03.00.005 release
- 482627d9 u-boot-ti-staging: Bump to 08.03.00.005 release
- afcf8534 conf: machine: am62xx: add new dtb for low-power
- a62d2268 ti-linux-fw: Bump to 08.03.00.004 release
- 2f296801 linux-ti-staging-rt: Bump to 08.03.00.004 release
- 76afbc34 linux-ti-staging: Bump to 08.03.00.004 release
- d391c3cd u-boot-ti-staging: Bump to 08.03.00.004 release
- 123bc260 conf: machine: am62xx Fix overlay extension
- 25b11044 ti-tros-firmware: Add DM firmware binary to deploy directory for am62xx-evm
- e210d36a ti-graphics: update for 4K/64K page size GPU drivers

Signed-off-by: Oleksandr Suvorov <oleksandr.suvorov@foundries.io>