### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1a2f586cecb3e15b19575d41dcfc6ee037897b7c"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5cc9008e38d1dc65e105a4f4dd54deb6c1f467fd"/>
   <project name="meta-clang" path="layers/meta-clang" revision="63a6101e27af6436eca646d0c887e4c4ed0760ef"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="50d4a8d2a983a68383ef1ffec2c8e21adf0c1a79"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 5cc9008e bsp: linux-lmp-fslc-imx: imx8mm-evkb: fix sdio options for wifi
- fbeb0f0b base: mxm-mwifiex-setup: add description of debug option
- 553cc347 bsp: linux-lmp: apalis-imx6: fix HDMI interface
- bc3efc49 base: rc: docker: Patch docker to fsync layer files
- 1c5cb942 bsp: lmp-machine-custom: make IMXBOOT_TARGETS hw specific for 8mn
- 6f9e562d bsp: conf: add imx8mn-lpddr4-evk-sec machine configuration
- 4ac6ace6 bsp: u-boot-fio/scr/base-files: add support for imx8mn-lpddr4-evk/sec
- 6f8bb264 bsp: mfgtool-files: add support for imx8mn-lpddr4-evk/sec
- ee35041f bsp: optee-os-fio: add support for imx8mn-lpddr4-evk
- eb9fa78e bsp: linux-lmp-fslc-imx: change imx8mn patch override to mx8mn-nxp-bsp
- 9c708ba8 bsp: lmp-machine-custom: add support for imx8mn-lpddr4-evk
- 9fbc8ae7 base: linux-lmp-dev-mfgtool: bump to 34103ef81ca9
- cbc5b1e9 bsp: linux-lmp-fslc-imx: bump to 34103ef81ca9
- ea2203a9 base: fioconfig: Bump revision for client cert rotation

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>