### PR TITLE
Dockerfile: install libgcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update \
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
 		android-sdk-libsparse-utils android-sdk-ext4-utils ca-certificates \
-		chrpath cpio diffstat file gawk g++ iproute2 iputils-ping less libmagickwand-dev \
+		chrpath cpio diffstat file gawk g++ iproute2 iputils-ping less libgcc1 libmagickwand-dev \
 		libmath-prime-util-perl libsdl1.2-dev libssl-dev locales \
 		openjdk-11-jre openssh-client perl-modules python3 python3-requests \
 		make patch repo sudo texinfo vim-tiny wget whiptail libelf-dev git-lfs screen \


### PR DESCRIPTION
The libgcc is now necessary to run bitbake.

The reason for the change is threading in bitbake itself and the thread.join() calls which seem to trigger pthread_cancel() calls under some circumstances.

Note that this is a distro python dependency problem. python is needing libgcc but is missing a dependency, that is the real issue.

https://lists.openembedded.org/g/openembedded-core/message/175684

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>