### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="535d9db42a0dd92533de9c08d8268d399dd0e882"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="67b0a2e85072da1a18a4b8a1cec6e27721914a43"/>
   <project name="meta-clang" path="layers/meta-clang" revision="b7c0dcc4bc7f0d273f14cc0a70bcad5555a4be04"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="1f31570d0795da90083d1dbf28127c90908e30ee"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 67b0a2e8 base:  add new base distros with wayland support
- cf93cf29 base: kmeta-linux-lmp-5.15.y: bump to ff4abc73
- 95846553 base: edk2-firmware: qemuarm64-secureboot-ebbr: publish qemu fd files
- 9e8e1322 bsp: lmp-machine-custom: adjust settings for qemuarm64-secureboot-ebbr
- f61b60d1 base: grub-efi: generate startup.nsh for every target
- e3ee56d8 base: non-clangable: build edk2-firmware with gcc
- dee88818 bsp: qemuarm64-secureboot-ebbr: add additional machine features
- bf9c58c9 base: trusted-firmware-a: qemuarm64-ebbr: depend on uefi instead of u-boot
- c5adb59a Revert "bsp: lmp-machine-custom: am64xx: exclude some receipes from the rm_work"
- de46bb24 bsp: lmp-machine-custom: switch to lmp-k3r5 machine variants
- 41d96cb5 base: lmp-staging: replace k3r5 with lmp-k3r5 in BBMULTICONFIG
- 0b4ffd7b bsp: lmp-machine-custom: adds SSTATE_ALLOW_OVERLAP_FILES_K3R5
- f7c591af bsp: multiconfig: add lmp-k3r5 machine variants to unshare the TMPDIR
- 6d20d75a base: lmp-staging: update copyright year
- 651a9b4d base: lmp-staging: use a variable with the compile locked recipes
- 4916812f Revert "base: lmp-staging: archiver multiconfig signature workaround"
- 6855f5e6 base: lmp-staging: prepend the variables with the classe name
- 313410cf bsp: lmp-machine-custom: add overrides for qemu-generic-arm64
- 7489e08c bsp: jailhouse: k3: add missing vtm memory node
- b162cf50 base: kmeta-linux-lmp-5.10.y: bump to 2b0fbe83
- 75b25c12 bsp: u-boot-ostree-scr-fit: am6x: unset bootupgrade_available
- b24f7ff9 bsp: base-files: am62xx-evm: add fstab
- 37120c1b base: remove 10-lite-public-stream.toml.in
- ad3559fd bsp: lmp-machine-custom: k3: enable OSTREE_DEPLOY_USR_OSTREE_BOOT
- b921a455 bsp: meta-ti: lmp-boot-firmware: depend on scr-fit
- 24877b48 bsp: lmp-machine-custom: set lmp boot files for am6xxx
- 479eb027 bsp: lmp-machine-custom: k3: add virtual/bootloader to WKS_FILE_DEPENDS
- a0a19b94 bsp: lmp-machine-custom: group am62xx-evm overrides
- c26b0cb8 bsp: linux-lmp-ti-staging: use standard lmp fragments
- c0bfeb6a base: kmeta-linux-lmp-5.10.y: bump to 53683670
- 71fd5991 bsp: u-boot-ti-staging: deploy u-boot config

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>