### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="6980e34bfe2bf7b2daa6e4abd544e889fe5b86ca"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="685aa4c412717d94662e764883259a2539532e8b"/>
   <project name="meta-clang" path="layers/meta-clang" revision="e33eec34a85bac111efbf034dfe782fe3c105b05"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="1f31570d0795da90083d1dbf28127c90908e30ee"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>


### PR DESCRIPTION
Relevant changes:
- 685aa4c4 bsp: linux-lmp-dev-mfgtool: bump to 3248ffcb12d1
- 43ba385f bsp: linux-lmp-fslc-imx: fix fsl_lpuart boot issue
- 9b006615 bsp: u-boot-ti-staging: am62xx-evm: use vfat for env
- 06c90db4 base: lmp: bump version for the 4.0.7 yocto release
- 1b7b4876 bsp: lmp-machine-custom: ti-soc: update ti-linux-fw to 08.06.00.004
- ccff50b0 bsp: u-boot-ti-staging: update to 08.06.00.004
- d12cb25f bsp: linux-lmp-ti-staging: update to 08.06.00.004
- 6a78fc1c bsp: bootbin: versal: op-tee loaded by PLM, booted by TF-A

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>