### PR TITLE
Update meta-lmp/meta-ti and fix LMP_VERSION_CACHE_DEV

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="e9c51b599b31c017481289abab049505e90d80e0"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="34598c55584fb83066a3587fa470e1edbb90795f"/>
   <project name="meta-clang" path="layers/meta-clang" revision="e33eec34a85bac111efbf034dfe782fe3c105b05"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="1f31570d0795da90083d1dbf28127c90908e30ee"/>
   <project name="meta-security" path="layers/meta-security" revision="c79262a30bd385f5dbb009ef8704a1a01644528e"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -16,5 +16,5 @@
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="a20e9664cba25ea33f7634e3c84c3c22d9ce14bb"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="df4da8dd068b4c96eee2a82a0f96946126db026a"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="574e833a9adf17a14484cae8b750b5cc36bc8d17"/>
+  <project name="meta-ti" path="layers/meta-ti" revision="38941472e1e30c57f89115a28ea751f5ae535bb2"/>
 </manifest>

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -247,10 +247,12 @@ ln -sf "${MANIFESTS}" "${OEROOT}"/layers/
 
 DISTRO_DIRNAME=$(echo "${DISTRO}" | sed 's#[.-]#_#g')
 
-LMP_VERSION_CACHE="${LMP_VERSION_CACHE:-$(git --git-dir ${MANIFESTS}/.git describe HEAD --tags --abbrev=0)}"
-if [ -v LMP_VERSION_CACHE_DEV ]; then
-    # to use the development version of the cache the user need to define the LMP_VER_DEV env
-    LMP_VERSION_CACHE=$(( $LMP_VERSION_CACHE + 1 ))
+if [ -z "$LMP_VERSION_CACHE" ]; then
+    LMP_VERSION_CACHE="$(git --git-dir ${MANIFESTS}/.git describe HEAD --tags --abbrev=0)"
+    if [ -v LMP_VERSION_CACHE_DEV ]; then
+        # to use the development version of the cache the user need to define the LMP_VERSION_CACHE_DEV env
+        LMP_VERSION_CACHE=$(( $LMP_VERSION_CACHE + 1 ))
+    fi
 fi
 
 cat > conf/auto.conf <<EOF


### PR DESCRIPTION
When we run setup-env more than once in the same shell environment we have problems because we will be incrementing in an infinite loop.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>