### PR TITLE
Dockerfile: Define WORKDIR to /build/lmp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,3 +104,6 @@ RUN mkdir -p /etc/apt/keyrings \
 RUN mkdir -p /usr/lib/docker/cli-plugins \
 	&& wget https://github.com/docker/compose/releases/download/v2.6.0/docker-compose-linux-x86_64 -O /usr/lib/docker/cli-plugins/docker-compose \
 	&& chmod +x /usr/lib/docker/cli-plugins/docker-compose
+
+WORKDIR /build/lmp
+


### PR DESCRIPTION
The directory /build/lmp is the one used in the documentation as the suggested place for the source code.

Please let me know if it is better to have WORKDIR defined at the beginning of the file instead.