### PR TITLE
lmp-base: update meta-ti layer

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -16,5 +16,5 @@
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="a20e9664cba25ea33f7634e3c84c3c22d9ce14bb"/>
   <project name="meta-sunxi" path="layers/meta-sunxi" revision="df4da8dd068b4c96eee2a82a0f96946126db026a"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="38941472e1e30c57f89115a28ea751f5ae535bb2"/>
+  <project name="meta-ti" path="layers/meta-ti" revision="e1a4db1708970b6f8358c341a3f2b65b08a5c8e6"/>
 </manifest>


### PR DESCRIPTION
Relevant changes:
- e1a4db17 ti-rtos-firmware: Deploy secure firmware unconditionally
- 5c49f478 ti-rtos-firmware: Fix use of base_libdir with nonarch_base_libdir
- 01840a80 ti-rtos-firmware: Use a table instead of a list of copy commands
- 70d79892 ti-rtos-firmware: Use defines to set firmware names
- 844778f9 ti-rtos-firmware: Use new ti-secdev class to sign the images
- ebe1ea98 u-boot-ti: Use new ti-secdev class to sign the images
- c821b2bb optee-os: Use new ti-secdev class to sign the images
- b7c909ce trusted-firmware-a: Use new ti-secdev class to sign the images
- 1df0827f meta-ti-bsp: Add helper class for TI Security Development Tools
- d3c07139 ti-linux-fw: update to the latest
- 24db544a ti-img-rogue-umlibs: handling the firmware installation with usrmerge
- 513ed650 ti-img-rogue-umlibs: drop unused patch
- b48f82cb conf/machine: fix use of screen and touchscreen machine features
- 9cc067da conf: machine: Fallback to software rendering
- 9c845e6e meta-ti-bsp: machine: set SGX display controller alias
- 38bf9791 meta-ti-bsp: machine: remove default preferences for egl,gles,gbm
- 56be4618 meta-ti-bsp: graphics: Resolve dependency chain
- fc281c3b mesa: locally overlay 22.0-specific patches from oe-core/kirkstone
- 4338e720 Revert "meta-ti-bsp: graphics: Resolve dependency chain"
- 69563462 Revert "meta-ti-bsp: machine: Remove all gpu features"
- 3529d4d4 Revert "meta-ti-bsp: machine: Attempt to update DC alias"
- 117731ce Revert "conf: machine: Fallback to software rendering"
- a4c92e96 conf: machine: Fallback to software rendering
- 1632c2f3 meta-ti-bsp: machine: Attempt to update DC alias
- 276c4204 meta-ti-bsp: machine: Remove all gpu features
- 87ed1e90 meta-ti-bsp: graphics: Resolve dependency chain
- 1c131324 conf/machine/k3r5.inc: update bootflow links
- 229a88e9 uio-module-drv: Remove deprecated uio-module-drv