### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="654f5c4c68b79c8dfe606dfb78fea663b3209f63"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="ea0b7641a5e0c93aaab5a178d65491349de34052"/>
   <project name="meta-clang" path="layers/meta-clang" revision="e33eec34a85bac111efbf034dfe782fe3c105b05"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="82c75b466e55d7dca7a2364986ecb704cf63d141"/>
   <project name="meta-security" path="layers/meta-security" revision="cc20e2af2ae1c74e306f6c039c4963457c4cbd0f"/>


### PR DESCRIPTION
Relevant changes:
- bd73fa69 base: u-boot-fio: 2022.04: bump to fd9b3d3ed4
- f85c5761 base: optee-os-fio: 3.20: bump to 8c03e4686
- 0568c30f base: linux-lmp: bump revision to 0a797be77f95
- 25330b26 base: linux: switch to 6.1 kernel
- efac9065 bsp: u-boot-ostree-scr-fit: stm32mp15: use scmi kernel dtb
- e7b6f4d7 bsp: u-boot-fio: stm32mp15: increase CONFIG_SYS_MALLOC_F_LEN
- d5deb94b bsp: lmp-machine: stm32mp15: use scmi device tree for kernel
- de108a27 lmp-machine-custom.inc: remove root= setting from OSTREE_KERNEL_ARGS
- 95d959c3 u-boot boot scripts: dynamically determine root= argument
- d2d75f47 bsp: optee: extend pkcs11 ta heap size
- 842527a1 base: tpm2-pkcs11: add patch to fix error during sign_init
- 36ea986f base: libp11: add 0.4.12 from meta-oe 6f342fe2
- f24925e1 base: tpm2-pkcs11: disable runtime warnings
- 36ab4c62 base: tpm2-tools: add 5.5 from meta-tpm rev 1ac7c66
- aee51bd4 base: tpm2-abrmd: add 3.0.0 from meta-tpm rev c06b9a1
- 4d8ff602 base: tpm2-tss: prefer /usr/lib for sysusers and tmpfiles
- 758825da base: lmp: set default pkgconfig for tpm2-tss with policy
- 17f5095d base: tpm2-tss: add 4.0.1 from meta-tpm rev e188be0
- 19752c1b base: openssl: add patch to allow tpm2-tss to load legacy EC keys
- 17432545 base: tpm2-pkcs11: backport patch for ecdh1 support
- 67c23345 base: tpm2-pkcs11: add 1.9.0 from meta-tpm rev 13653bf
- bceb8374 base: layer: adjust tpm-layer priority
- 660d6ba4 base: u-boot-ostree-src-fit: handle bootupgrade_available corner case
- 37dc0fd4 bsp: u-boot-fio: imx8mp-lpddr4-evk: lmp-base: disable unused options
- cbae4820 bsp: u-boot-fio: imx8mn-lpddr4-evk: fix config options
- ffcc7a3e bsp: u-boot-fio: imx8mn-ddr4-evk: fix config options
- d5815bfb bsp: u-boot-fio: imx8mp-lpddr4-evk: fix config options
- e7b7ad88 bsp: bootimg-sota-efi: allow dynamic bootable partition
- 292595e1 base/bsp: update optee to 3.20
- cc651e05 base: optee-os-fio-se05x: enable rsa/ecc fallback
- 785cf49c base: optee-os-fio-se05x: update plug-and-trust
- d1ef01ca bsp: lmp-machine-custom: use SDMA firmware from firmware-imx
- e4a09db2 bsp: linux-firmware: drop sdma packages
- 0543fc0c bsp: firmware-imx: install sdma-imx6q/7d
- dcc1fd19 base: kmeta-linux-lmp-5.15.y: bump to d55fd7d3
- 96d2de1f base: non-clangable: add kernel settings for linux-tegra-rt
- b4114c6d bsp: tegra: add linux-tegra-rt 5.10 recipe
- f62b3558 bsp: tegra: rename append to cover all variants