### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7f82877142a5cd048cde6eba526fc75a29ffee6c"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7c34fae416dfcc10756bb59d3bf6ae44f2d1c334"/>
   <project name="meta-clang" path="layers/meta-clang" revision="e33eec34a85bac111efbf034dfe782fe3c105b05"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="9cf4ebeb3de524009a73f49722489dc4aa183adb"/>
   <project name="meta-security" path="layers/meta-security" revision="cc20e2af2ae1c74e306f6c039c4963457c4cbd0f"/>


### PR DESCRIPTION
Relevant changes:
- 7c34fae4 base: kmeta-linux-lmp-5.10.y: bump to 902d575b
- 81612c83 bsp: linux-lmp-ti-staging: update to 08.06.00.007
- 3fb46ac6 bsp: u-boot-ti-staging: update to 08.06.00.007
- f21da0db bsp: lmp-machine-custom: ti-soc: update ti-linux-fw to 08.06.00.007
- 5597a749 base: lmp: disable buildhistory
- 691ed142 Revert "base: lmp: enable create-spdx bbclass by default"
- 24e9a5bb Revert "base: lmp: inherit archiver"
- 071ef2e0 Revert "base: lmp: archiver: disable by default"
- ec4bfef0 bsp: u-boot-ostree-scr-fit: am62: allow loading dt overlays
- 70d419bf bsp: jailhouse: k3: fix bar mask size
- 043ebb02 bsp: lmp-machine-custom: am62: autoload jailhouse and uio_ivshmem when enabled
- 820f211e bsp: lmp-machine-custom: am62xx-evm: define UBOOT_DTBO_LOADADDRESS
- e5f03b80 base: lmp: bump version for the 4.0.8 yocto release