### PR TITLE
lmp-base: adds meta-lts-mixins

### DIFF
--- a/conf/bblayers-base.inc
+++ b/conf/bblayers-base.inc
@@ -10,6 +10,7 @@ BASELAYERS = " \
   ${OEROOT}/layers/meta-openembedded/meta-python \
   ${OEROOT}/layers/meta-virtualization \
   ${OEROOT}/layers/meta-clang \
+  ${OEROOT}/layers/meta-lts-mixins \
   ${OEROOT}/layers/meta-updater \
   ${OEROOT}/layers/meta-security \
   ${OEROOT}/layers/meta-security/meta-tpm \

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,6 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7c34fae416dfcc10756bb59d3bf6ae44f2d1c334"/>
   <project name="meta-clang" path="layers/meta-clang" revision="e33eec34a85bac111efbf034dfe782fe3c105b05"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="9cf4ebeb3de524009a73f49722489dc4aa183adb"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins" remote="fio" revision="067f1a4108d2df2db89724404abb56ec7e6f169d"/>
   <project name="meta-security" path="layers/meta-security" revision="cc20e2af2ae1c74e306f6c039c4963457c4cbd0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="ffbbc2b9f46a60bd2d51be53079252f8e6304a8b"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="a7413c5d7568ce91b809ed11f84305b1afb468bb"/>


### PR DESCRIPTION
This will bring-up latest `go` backported from oe-core master branch, currently `go-1.21`