### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="05bc8f5cf6a4e1988b1e5d3a822d8e3870794fb2"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="57d569c289a3039f5b45b47b3cadca902f7384d2"/>
   <project name="meta-clang" path="layers/meta-clang" revision="e33eec34a85bac111efbf034dfe782fe3c105b05"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="9cf4ebeb3de524009a73f49722489dc4aa183adb"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins" remote="fio" revision="067f1a4108d2df2db89724404abb56ec7e6f169d"/>


### PR DESCRIPTION
Relevant changes:
- 1f0202b3 optee-test: disable test 1039
- 71776aa7 base: optee-os-fio-se05x: update plug-and-trust to v04.03.01
- 1ffce71d bsp: tegra-helper-scripts: add support to flash wic on external devices
- 8b031128 bsp: tegra-helper-scripts: import initrd-flash.sh script
- 1ac71c2e bsp: tegra-flash-init: add command to format mmc partitions
- 3b9bc7f0 bsp: lmp-machine-custom: tegra: allow rootfs image as wic
- 61255b48 bsp: edk2-firmware-tegra: support otaroot and disable a/b rootfs
- d963c55f bsp: lmp-machine-custom: tegra194: use label for the rootfs
- bf4b8126 base: efidisk-sota.wks: also set rootfs part-name
- b49ed7f5 bsp: lmp-machine-custom: tegra: set IMAGE_ROOTFS_SIZE to 65536
- 7dbe75dd bsp: lmp-machine-custom: tegra: also generate standard wic image
- d8460fa0 bsp: bootimg-sota-efi: add support for l4t-launcher
- e9a38d30 bsp: edk2-firmware-tegra: deploy l4t-launcher
- a7df8964 bsp: lmp-machine-custom: tegra: add back resize-helper
- 3c128e0f base: resize-helper: only change ptable if rootfs is the last partition
- 7693fc6b base: resize-helper: fix ID_PART_ENTRY_NAME grep
- 1d3579dd bsp: linux-lmp-toradex-imx: bump to toradex_5.15-2.1.x-imx
- 17e1922c base: kmeta-linux-lmp-5.15: bump to 605b27f
- 185afbd6 bsp: linux-lmp-toradex-imx: apalis-imx8: remove unused patch
- 703089c6 base: linux-lmp: bump revision to e42763ec16a4
- 2ff02156 bsp: stm32mp15: explicitly add linux-firmware-bcm43430
- 6c0561c1 bsp: kernel: firmware: install calibration for scmi-ready machines
- 09931d4f base: distro: enable alsa feature by default
- 6c9b4361 base: packagegroup-base: add aplay/arecord to alsa base group
- 4360f664 base: images: feature: debug: add full alsa
- e2a1cfa5 base: alsa-utils: also lookup for asound.state in /usr/lib/alsa
- cc462235 base: alsa-state: install asound.state into /usr/lib/alsa
- c337eccd base: unify comparing values