### PR TITLE
setup-environment-internal: print sstate cache info 

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -404,6 +404,7 @@ Your build environment has been configured with:
 
     MACHINE = ${MACHINE}
     DISTRO = ${DISTRO}
+    $(bitbake-getvar SSTATE_MIRRORS | tail -n1)
 
 You can now run 'bitbake <target>'
 


### PR DESCRIPTION
1. Drop LMP_VERSION_CACHE_DEV, and let user define LMP_VERSION_CACHE explicitly with the value he needs. This helps to avoid issues when both LMP_VERSION_CACHE and LMP_VERSION_CACHE_DEV are defined in the environment, and leads to unexpected results.
2. Print version of LMP_VERSION_CACHE if it's set. Example: LMP state cache is enabled:
    LMP_VERSION_CACHE = 90
    SSTATE remote url = https://storage.googleapis.com/lmp-cache/v90-sstate-cache