### PR TITLE
setup-environment-internal: print sstate mirror url

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -404,10 +404,25 @@ Your build environment has been configured with:
 
     MACHINE = ${MACHINE}
     DISTRO = ${DISTRO}
-    $(bitbake-getvar SSTATE_MIRRORS | tail -n1)
 
 You can now run 'bitbake <target>'
 
+EOF
+
+if [ -z "$LMP_VERSION_CACHE" ]; then
+	cat <<EOF
+LMP state cache mirror is disabled.
+
+EOF
+else
+	cat <<EOF
+LMP state cache mirror is enabled, mirror url:
+    https://storage.googleapis.com/lmp-cache/v$LMP_VERSION_CACHE-sstate-cache
+
+EOF
+fi
+
+cat <<EOF
 Some common targets are:
 EOF
 


### PR DESCRIPTION
Print directly sstate cache mirror url instead of using bitbake-getvar, which delays the execution and also generates cache.