### PR TITLE
setup-environment-internal: use a wrapper to show the SSTATE_MIRRORS during the build

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="17f4662d1416a61337016809b7c08829246c8a74"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="30c68d5b41c455c89d94bb9974a869051e42c841"/>
   <project name="meta-clang" path="layers/meta-clang" revision="7e3f2a4126d1bfacda497dfa6b59f3f471f1a984"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="571e36e20e9d1f27af0eb4545291beeb64f280e2"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins" revision="7161f2f7be64b42f0247e3f2255cb7dc57281b6d"/>

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -404,25 +404,10 @@ Your build environment has been configured with:
 
     MACHINE = ${MACHINE}
     DISTRO = ${DISTRO}
+    $(bitbake-getvar SSTATE_MIRRORS | tail -n1)
 
 You can now run 'bitbake <target>'
 
-EOF
-
-if [ -z "$LMP_VERSION_CACHE" ]; then
-	cat <<EOF
-LMP state cache mirror is disabled.
-
-EOF
-else
-	cat <<EOF
-LMP state cache mirror is enabled, mirror url:
-    https://storage.googleapis.com/lmp-cache/v$LMP_VERSION_CACHE-sstate-cache
-
-EOF
-fi
-
-cat <<EOF
 Some common targets are:
 EOF
 

--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -404,7 +404,6 @@ Your build environment has been configured with:
 
     MACHINE = ${MACHINE}
     DISTRO = ${DISTRO}
-    $(bitbake-getvar SSTATE_MIRRORS | tail -n1)
 
 You can now run 'bitbake <target>'
 


### PR DESCRIPTION
Use a wrapper [1] to show the SSTATE_MIRRORS during the build.
[1] https://github.com/foundriesio/meta-lmp/pull/1100
