### PR TITLE
conf/local.conf: use weak default value for MODSIGN_KEY_DIR

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -58,7 +58,7 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-lmp"
 # By default LmP kernel is configured to load only signed modules.
 # The default key provided should only be used for development purposes.
 # To create a custom signing key, follow the instructions on kernel documentation.
-MODSIGN_KEY_DIR ?= "${TOPDIR}/conf/keys"
+MODSIGN_KEY_DIR ??= "${TOPDIR}/conf/keys"
 MODSIGN_KEY_DIR[vardepsexclude] += "TOPDIR"
 
 #


### PR DESCRIPTION
The Foundries global keys in conf/keys are supposed to be used only when a factory hasn't been configured. When a factory is configured, factory-specific keys are created in the factory-keys directory, and meta-subscriber-overrides has lmp-factory-custom.inc that points to this directory.

However, both lmp-factory-overrides.inc and local.conf use ?= to assign to MODSIGN_KEY_DIR. In this case, it's the one in local.conf that ends up being used. In other words, even after instantiating a factory, the global Foundries development keys are still used to sign kernel modules.

Fix this by using a weak default value (??=) instead of a default value in local.conf. This is what is used for setting all the other keys in local.conf.