### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4138c80759b8b9cdbd06f861f52f767b8b3e52d9"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5ee52617837eb53883e269f8dd9d52d93c5f187f"/>
   <project name="meta-clang" path="layers/meta-clang" revision="7e3f2a4126d1bfacda497dfa6b59f3f471f1a984"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="571e36e20e9d1f27af0eb4545291beeb64f280e2"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins" revision="7161f2f7be64b42f0247e3f2255cb7dc57281b6d"/>


### PR DESCRIPTION
Relevant changes:
- 5ee52617 bsp: u-boot-base-scr: Add imx93-lpddr4-evk support
- 717c78bf bsp: base-files: Add fstab for imx93-11x11-lpddr4x-evk
- 6c91ca76 bsp: lmp-mfgtool-machine-custom: add support for mx93
- 902387d4 base: u-boot-ostree-scr-fit: split boot-common scripts
- b41319da base: u-boot-ostree-scr-fit: align boot firmware update helpers
- 2988b06f base: u-boot-ostree-scr-fit: move fiovb.old_is_secondary_boot check
- 1b438a01 base: u-boot-ostree-scr-fit: align debug env printing
- 896faec8 base: u-boot-ostree-scr-fit: standartize bootupgrade_primary_updated
- 41a0d6e3 base: u-boot-ostree-scr-fit: alternative: check for ostree_deploy_usr
- 50c9ade2 bsp: u-boot-ostree-scr-fit: zynqmp: add do_reboot definition
- 2878cdd3 base: u-boot-ostree-scr-fit: move env definitions for boot steps
- 204ebcd5 base: u-boot-ostree-scr-fit: alternative: move primary recovery
- 37f35f34 base: u-boot-ostree-scr-fit: common: move forcing primary
- 71686935 base: lmp: bump version for the 4.0.9 yocto release