### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="8e248e1040526c5de24972f0a13a61b2398aa32e"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="1933867a894d0afa3ab14f1c6d06ed003cd9c7f1"/>
   <project name="meta-clang" path="layers/meta-clang" revision="7e3f2a4126d1bfacda497dfa6b59f3f471f1a984"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="571e36e20e9d1f27af0eb4545291beeb64f280e2"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins" revision="7161f2f7be64b42f0247e3f2255cb7dc57281b6d"/>


### PR DESCRIPTION
Relevant changes:
- 1933867a bsp: lmp-machine-custom: add support for mx93 machines
- 4261f4c3 bsp: wic: add emmc-imx-gpt-sota.wks
- 4f6e87ab bsp: freescale-layer: jailhouse: mx93: drop cortex-a55 tune
- d9ee8650 bsp: u-boot-fio: imx93-11x11-lpddr4x-evk: add fw_env
- eb199a8d bsp: optee-os-fio-bsp/mfgtool: add support for imx93-11x11-lpddr4x-evk
- 09a78d6e bsp: u-boot-ostree-scr-fit: add boot.cmd for imx93-11x11-lpddr4x-evk
- aa4ed265 bsp: lmp-mfgtool-machine-custom: mx93: set imxboot target to singleboot
- 9ebc2070 bsp: mfgtool-files: add the script files for imx93-11x11-lpddr4x-evk
- 15a5aee3 bsp: mfgtool-files: add imx-boot dependency for mx93-nxp-bsp machines
- 6d3d553b bsp: u-boot-fio-mfgtool: add config for imx93-11x11-lpddr4x-evk
- 9cfb27e5 bsp: u-boot-fio: add config for imx93-11x11-lpddr4x-evk
- 0a01382e bsp: u-boot-fio-bsp-common.inc: Add do_deploy for mx9-nxp-bsp
- 23507450 bsp: imx-atf: add do_deploy for mx9-nxp-bsp
- facb0c69 bsp: imx-boot: mx93: add support for spl-only build
- fe0e13f3 base: u-boot-fio: imx-2022.04: bump to 8dbf7957dc3
- e1cc0e47 base: kmeta-linux-lmp-5.15.y: bump to a7ae63e3
- ec5d1551 docker: fix dockerd failed start conditions
- e35d9d3e aktualizr-lite: reboot on failed start