### PR TITLE
[v90] Add latest CVE fixes

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -16,5 +16,5 @@
   <project name="meta-security" path="layers/meta-security" revision="cc20e2af2ae1c74e306f6c039c4963457c4cbd0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="dc9374589a8d05fde18654d5bbc75c205065e0e1"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="a7413c5d7568ce91b809ed11f84305b1afb468bb"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="ff4b57ffff903a93b710284c7c7f916ddd74712f"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="b67e714b367a08fdeeeff68c2d9495ec9bc07304"/>
 </manifest>


### PR DESCRIPTION
Include this to https://github.com/foundriesio/lmp-manifest/pull/322

This update includes CVE fixes.

Relevant changes:
- b67e714b36 package.bbclass: correct check for /build in copydebugsources()
- 26b4db753c openssl: Move microblaze to linux-latomic config
- e5cf04f55b go: fix CVE-2022-41724, 41725
- d1aa26fe81 tiff: Add fix for CVE-2022-4645
- 7919a5a5ea curl: CVE-2023-27534 SFTP path resolving discrepancy
- ff79587253 curl: CVE-2023-27533 TELNET option IAC injection
- d478e7ea0b binutils : Fix CVE-2023-1579