### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="164b3b73568bb071dae904d791dca20fbe12da4b"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="6e74f8c8cdf59abb46aed7859a988b11c2f68f8a"/>
   <project name="meta-clang" path="layers/meta-clang" revision="68ec449f97ffa58d835163581fc72afcb08f027b"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="df452d9d98659b49888fa8a5428a0a8bd3e3aaec"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins" revision="691dde801b009d928fbf8a820dace69dca91eb29"/>


### PR DESCRIPTION
Relevant changes:
- 6e74f8c8 base: ostree-kernel-initramfs: the default dependencies is not needed
- 1f1259f0 base: lmp-staging: check_deployed_depends: make this a warn instead of an error
- 00b94120 bsp: stm32-mfgtool-files/stm32-mfgtool-files: set DEPENDS acording 'do_deploy' presence on task[depends]
- 390318db bsp: u-boot-xlnx: set DEPENDS acording 'do_deploy' presence on task[depends]
- bce1b034 bsp: flashlayouts-stm32mp1: set DEPENDS acording 'do_deploy' presence on task[depends]
- ab271d8c bsp: imx-boot: set DEPENDS acording 'do_deploy' presence on task[depends]
- 9f185e15 bsp: linux-lmp-toradex-imx: set DEPENDS acording 'do_deploy' presence on task[depends]
- b1bd0f34 base: mfgtool-files: set DEPENDS acording 'do_deploy' presence on task[depends]
- 759e8c7d base: uboot-fitimage: set DEPENDS acording 'do_deploy' presence on task[depends]
- c0d96e0c base: ostree-kernel-initramfs: set DEPENDS acording 'do_deploy' presence on task[depends]
- 1200ed8d base: fip-utils: set DEPENDS acording 'do_deploy' presence on task[depends]
- 00d1a1f0 base: lmp-boot-firmware: set DEPENDS acording 'do_deploy' presence on task[depends]
- 008b6625 bsp: u-boot-xlnx: skip checking 'do_deploy' in depends
- b1c4c78d base: u-boot-fio-common: skip checking 'do_deploy' in depends
- 6a6fa99d base: lmp-staging: add an handler to check bad usage of 'do_deploy' in depends
- 3eec8009 bsp: linux-lmp-rpi: 5.10.110 -> 5.15.92
- 65d83012 bsp: linux-lmp-rpi: update 5.10 recipe to latest revision
- 5a10feac bsp: linux-lmp-rpi: update to 5.10.110
- e4ddcd9a libp11: fix libp11 to enable lmp-device-register refactor