### PR TITLE
dockerfile: Bump ostreeuploader to b3732aa (2023.6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -P /tmp https://go.dev/dl/go1.19.9.linux-amd64.tar.gz && \
 ENV PATH /usr/local/go/bin:$PATH
 
 RUN git clone https://github.com/foundriesio/ostreeuploader.git /ostreeuploader && \
-    cd /ostreeuploader && git checkout -q 2023.5 && \
+    cd /ostreeuploader && git checkout -q 2023.6 && \
     cd /ostreeuploader && make
 
 


### PR DESCRIPTION
Relevant changes:
  - 1d57fed fiopush: Support just `v2` ostreehub API version
  - b3732aa fiocheck: Support just `v2` ostreehub API version