### PR TITLE
dockerfile: Bump ostreeuploader version 7dd03e5 (2023.6)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -P /tmp https://go.dev/dl/go1.19.9.linux-amd64.tar.gz && \
 ENV PATH /usr/local/go/bin:$PATH
 
 RUN git clone https://github.com/foundriesio/ostreeuploader.git /ostreeuploader && \
-    cd /ostreeuploader && git checkout -q 2023.5 && \
+    cd /ostreeuploader && git checkout -q 2023.6 && \
     cd /ostreeuploader && make
 
 


### PR DESCRIPTION
The new version accepts the `api-version` CLI param for backward compatibility. But it will yield an error if a client passes other than  `v2` value since the backend supports only `v2.`