### PR TITLE
lmp-base: update meta-lts-mixins layer go branch

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="64676e6e980ccc0acd7571fdcb79d970f0e5ebba"/>
   <project name="meta-clang" path="layers/meta-clang" revision="71321ddf78ea522b87a6b4bffefb14c988a6d921"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="5f120a926b0fcd55cfe7565bb7ddf23661cad498"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="691dde801b009d928fbf8a820dace69dca91eb29"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="3ea341bbd30756a114f37cd5ea4305eb14ebea09"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="feed1bb0eb4aefb701d582156d7defb0c1fc0473"/>
   <project name="meta-security" path="layers/meta-security" revision="cc20e2af2ae1c74e306f6c039c4963457c4cbd0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="be1217764c926e46acdaf9e8d1fa6404090723f5"/>


### PR DESCRIPTION
Relevant changes:
- 3ea341b go: Use -no-pie to build target cgo
- 239e5eb go: Upgrade 1.20.1 -> 1.20.4