### PR TITLE
setup-environment-internal: avoid using obsolete egrep

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -143,7 +143,7 @@ export BB_ENV_PASSTHROUGH_ADDITIONS="MACHINE DISTRO TCLIBC TCMODE GIT_PROXY_COMM
 
 mkdir -p "${BUILDDIR}"/conf && cd "${BUILDDIR}"
 if [ -f "conf/auto.conf" ]; then
-    oldmach=$(egrep "^MACHINE" "conf/auto.conf" |
+    oldmach=$(grep -E "^MACHINE" "conf/auto.conf" |
              sed -e 's%^MACHINE ?= %%' | sed -e 's/^"//' -e 's/"$//')
 fi
 


### PR DESCRIPTION
egrep is obsolescent. It is now an alias for "grep -E" [1]. Update the commands to avoid wrappings and warnings.

[1]
$ egrep -V
egrep: warning: egrep is obsolescent; using grep -E grep (GNU grep) 3.8