### PR TITLE
switch meta-freescale to master

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="64921318d06d9150a67e64e37d1476aa0e80c82a"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="605da03a180a42aa5ff4bdb077e7a0b98d8ce938"/>
   <project name="meta-clang" path="layers/meta-clang" revision="35231498962d0f3e75866c7e20ae6b2f87a2ae28"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a82d92c8a6525da01524bf8f4a60bf6b35dcbb3d"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="315d2d288fdcd2768f189101d980f40b0f2c9b0d"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="96aad3b29aa7a5ee4df5cf617a6336e5218fa9bd"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="63169d4ba8fd427b0a95c9e666864291e7c191ce"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="2805e245f6d49d2db4028698dcd116a38c37235f"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="bf12dc09d88a53d7345377de277fbcc20ed87235"/>
   <project name="meta-intel" path="layers/meta-intel" revision="1edf26e5b90371c9acf7bd6ac7155000de85f133"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="2a06e4e84b04fc900f3a4524581548c9b5e57362"/>


### PR DESCRIPTION
Since the master branch of meta-freescale is still compatible with kirkstone and only this branch supports NXP BSP LF6*, we need to switch to this branch before updating kernel linux-lmp-fslc-imx to 6.x.
