### PR TITLE
lmp-bsp: update meta-ti layer

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -15,5 +15,5 @@
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="f8d8efab12040712df32436643621b2756de1f76"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="48b6a1454caa4f17862bd185d5f08e00f1aed629"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="b86456651b1b9ce1e0612f9892387ec54b4f5759"/>
+  <project name="meta-ti" path="layers/meta-ti" revision="522370739fe8f1c9a5e7eeb50a0832140a95291d"/>
 </manifest>


### PR DESCRIPTION
Relevant changes:
- 52237073 linux-ti-staging_6.1: CI/CD Auto-Merger: cicd.kirkstone.202306291638
- 46af910c linux-ti-staging-rt_6.1: CI/CD Auto-Merger: cicd.kirkstone.202306291638
- 31e86709 u-boot-ti-staging_2023.04: CI/CD Auto-Merger: cicd.kirkstone.202306291638
- 2b8dae23 ti-linux-fw: CI/CD Auto-Merger: cicd.kirkstone.202306291638
- 1a4e866e conf: machine: j7*: Update KERNERL_DEVICETREE_PREFIX to match latest filenames
- 08e38940 ti-img-rogue-driver: drop unused patch
- 92decee8 ti-img-rogue-driver: update to catch more compilers
- 818aa0aa ti-img-rogue-umlibs: absolute path for file globs
- 19938f95 linux-ti-staging: add configuration for remoteproc/rpmsg IPC modules
- 6352c729 ti-img-rogue-umlibs: use rrecommends for components