### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="538f31c5dd3704a8a17c86f386ba05bfcbbcd18f"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="28ef81341304353f4c4556ff577214e41b1c4643"/>
   <project name="meta-clang" path="layers/meta-clang" revision="35231498962d0f3e75866c7e20ae6b2f87a2ae28"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a82d92c8a6525da01524bf8f4a60bf6b35dcbb3d"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="315d2d288fdcd2768f189101d980f40b0f2c9b0d"/>


### PR DESCRIPTION
Relevant changes:
- 28ef8134 base: kmeta-linux-lmp-6.1.y: bump to cc5d0ac1
- d675b46a bsp: lmp-machine-custom: apalis-imx6: use in-kernel imx BSP defconfig
- b6f5d963 bsp: linux-lmp-dev-mfgtool: drop custom defconfigs
- e7a36afb base: linux-lmp-dev-mfgtool: use standard bsp defconfig
- aba58af5 bsp: linux-lmp-dev-mfgtool: update to 6.1-1.0.x-imx