### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="28ef81341304353f4c4556ff577214e41b1c4643"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="51caa20decd7cea2ceaeb169273ebcd089b45274"/>
   <project name="meta-clang" path="layers/meta-clang" revision="35231498962d0f3e75866c7e20ae6b2f87a2ae28"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a82d92c8a6525da01524bf8f4a60bf6b35dcbb3d"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="315d2d288fdcd2768f189101d980f40b0f2c9b0d"/>


### PR DESCRIPTION
Relevant changes:
- 51caa20d base: htpdate: update to 1.3.7
- 6e8b313d base: lshw: bump to b4e0673
- 96dc7490 base: lshw: import changes from meta-oe master 7082ee8e0
- 0bddcfe2 base: ima-inspect: update to 0.15
- 5efa398d bsp: drop linux-lmp-fslc-imx_git.bb (5.15 based)
- 6fab660e bsp: linux-lmp-fslc-imx-rt: update kernel to the 6.1-based branch
- d6f36225 base: layer.conf: exclude os-release siggen dependencie on the mfgtool-initramfs