### PR TITLE
Dockerfile: install tools to run the pybootchartgui

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
 		make patch repo sudo texinfo vim-tiny wget whiptail libelf-dev git-lfs screen \
 		socket corkscrew curl xz-utils tcl libtinfo5 device-tree-compiler python3-pip python3-dev \
 		tmux libncurses-dev vim zstd lz4 liblz4-tool libc6-dev-i386 \
-		awscli docker-compose gosu \
+		awscli docker-compose gosu xvfb python3-cairo python3-gi-cairo yaru-theme-icon \
 	&& ln -s /usr/bin/python3 /usr/bin/python \
 	&& pip3 --no-cache-dir install expandvars jsonFormatter \
 	&& apt-get autoremove -y \


### PR DESCRIPTION
In LmP build we have the buildstats enabled because we use the
INHERIT += "buildstats" but the output is hard to read and understand.
The openembedded-core pybootchartgui scripts can process this logs and
generates some pretty charts.

```
| Running: apt-get install -y --no-install-recommends xvfb python3-cairo python3-gi-cairo yaru-theme-icon |  Reading package lists...
|  Building dependency tree...
|  Reading state information...
|  The following additional packages will be installed:
|    libfontenc1 libunwind8 libxfont2 libxkbfile1 libxmuu1 x11-xkb-utils xauth
|    xkb-data xserver-common
|  Recommended packages:
|    xfonts-base
|  The following NEW packages will be installed:
|    libfontenc1 libunwind8 libxfont2 libxkbfile1 libxmuu1 python3-cairo
|    python3-gi-cairo x11-xkb-utils xauth xkb-data xserver-common xvfb
|    yaru-theme-icon
|  0 upgraded, 13 newly installed, 0 to remove and 18 not upgraded.
|  Need to get 15.4 MB of archives.
|  After this operation, 83.4 MB of additional disk space will be used.
```