### PR TITLE
lmp-base: update meta-lts-mixins layer go branch

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9facd8267cb55f8ef4ec3da202c47acd87f7269f"/>
   <project name="meta-clang" path="layers/meta-clang" revision="5563999cd1e3b9e29532df8d6f2b3c9475f96833"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="346753705e49a2486867dc150181a1c7f4d69377"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="6e9008a6765d7059414494b794c503ddc0965ef0"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="b5e356d36d6fca67cbe379aed4a84223600bcb5d"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="feed1bb0eb4aefb701d582156d7defb0c1fc0473"/>
   <project name="meta-security" path="layers/meta-security" revision="d398cc6ea6716afd3a3a6e88ad8fbdc89510ef23"/>
   <project name="meta-updater" path="layers/meta-updater" revision="9f7fe77932671751f3c7201d164ffbabd0cb2faf"/>


### PR DESCRIPTION
Relevant changes:
- b5e356d README: remove Alex from maintainers
- 9822156 go: update 1.20.5 -> 1.20.6