### PR TITLE
setup-environment-internal: adjust target suggestions

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -411,10 +411,17 @@ Some common targets are:
 EOF
 
 if [ "${DISTRO}" = 'lmp-mfgtool' ]; then
+    if [[ "${MACHINE}" == *"stm32mp1"* ]]; then
+        cat <<EOF
+    stm32-mfgtool-files           - MFGTOOL Support Files and Binaries for board flashing and provisioning (STM32MP1 machines)
+
+EOF
+    else
         cat <<EOF
     mfgtool-files           - MFGTOOL Support Files and Binaries for board flashing and provisioning
 
 EOF
+    fi
 else
 
         cat <<EOF


### PR DESCRIPTION
Print different lmp-mfgtool target suggestions depending on machine.

Change-Id: Ief0b2c4f70b75af7fbd07f2c237c4fc6c91b4fb2