### PR TITLE
conf/local.conf: default configuration for stm32 signing tool

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -100,3 +100,12 @@ TF_A_SIGN_KEY_PATH[vardepsexclude] += "TOPDIR"
 UEFI_SIGN_KEYDIR ??= "${TOPDIR}/conf/keys/uefi"
 UEFI_SIGN_KEYDIR[vardepsexclude] += "TOPDIR"
 #UEFI_SIGN_ENABLE ?= "1"
+
+#
+# STM32CubeProgrammer STM32MP Signing Tool configuration
+#
+#STM32_ROT_SIGN_ENABLE ??= "1"
+#STM32_CUBE_PATH ??= "/usr/local/STMicroelectronics/STM32Cube/STM32CubeProgrammer"
+STM32_ROT_KEY_PATH ??= "${TOPDIR}/../tools/lmp-tools/security/stm32mp1/"
+STM32_ROT_KEY_PATH[vardepsexclude] += "TOPDIR"
+STM32_ROT_KEY_PASSWORD ??= "foundries"


### PR DESCRIPTION
Provide default configuration for STM32CubeProgrammer STM32MP Signing Tool.