### PR TITLE
lmp-base: update meta-lts-mixins layer go branch

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="d4ea7840b0ef58e0cf7ecd518b3be2fd0a166a2a"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="00ebb0c3901065dd5e71385090c53e4abc419187"/>
   <project name="meta-clang" path="layers/meta-clang" revision="5563999cd1e3b9e29532df8d6f2b3c9475f96833"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4da92ed9be41734f6ced46b981958e2e868cbff2"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="708a0db8675c2e445b6fc09310a06538759ed88e"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="d4ea7840b0ef58e0cf7ecd518b3be2fd0a166a2a"/>
   <project name="meta-clang" path="layers/meta-clang" revision="5563999cd1e3b9e29532df8d6f2b3c9475f96833"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4da92ed9be41734f6ced46b981958e2e868cbff2"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="b5e356d36d6fca67cbe379aed4a84223600bcb5d"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="708a0db8675c2e445b6fc09310a06538759ed88e"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="feed1bb0eb4aefb701d582156d7defb0c1fc0473"/>
   <project name="meta-security" path="layers/meta-security" revision="d398cc6ea6716afd3a3a6e88ad8fbdc89510ef23"/>
   <project name="meta-updater" path="layers/meta-updater" revision="9f7fe77932671751f3c7201d164ffbabd0cb2faf"/>


### PR DESCRIPTION
Relevant changes:
- 708a0db go: upgrade 1.20.6 -> 1.20.7