### PR TITLE
Revert firmware sentinel update for imx93/8ulp

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="96aad3b29aa7a5ee4df5cf617a6336e5218fa9bd"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="e4d721f735aba27f0f1a478dba1b28f738cd1e9d"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="863c8117920280d922d48efbce3ffdc4318d5526"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="b3be00d8c8cd80d89b04b4dc81bf008025d0c53a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="1342bcdc5bfc6620737e7d195e7d9bd744348577"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="43683cb14b6afc144619335b3a2353b70762ff3e"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="96aad3b29aa7a5ee4df5cf617a6336e5218fa9bd"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="863c8117920280d922d48efbce3ffdc4318d5526"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="1368ed190cc8e8a1dcd78d6cb5af39af3ee18235"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="b3be00d8c8cd80d89b04b4dc81bf008025d0c53a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="1342bcdc5bfc6620737e7d195e7d9bd744348577"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="43683cb14b6afc144619335b3a2353b70762ff3e"/>


### PR DESCRIPTION
Requires a more recent optee-os release, which is still wip in lmp.