### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="96c4346a95991924a75cfc85c9f953b58e459c60"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="a2967e5cfdf1aea6019791f41872157204d28730"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2d08d6bf376a1e06c53164fd6283b03ec2309da4"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a88cb922f91fda95e8a584cee3092083d5ad3e98"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="d8b9a33feaf72147c83c22a1ef7daacbe6a9a992"/>


### PR DESCRIPTION
Relevant changes:
- a2967e5c base: docker: update to v24.0.6
- ea38c166 base: docker-compose: update to v2.21.0
- 03405b22 base: containerd-opencontainers: update to 1.7.3
- 4ca9913b base: runc-opencontainers: update to 1.1.8
- b4c8f7a9 base: rc: Patch docker to load image optimally
- f642d99c lmp-el2go-auto-register: allow to disable "composeapp"
- 233caec9 Revert "base: nerdctl: install the binaries in OE standard places"
- 740789f2 base: nerdctl: fix installed-vs-shipped with usrmerge
- 2756e5af bsp: linux-lmp-fslc-imx-rt: update kernel to nxp real-time-edge version
- 9511c399 base: kmeta-linux-lmp-6.1.y.inc: bump to dc3aada8
- 5461c43a base: linux-lmp-rt: 6.1: bump to v6.1.54-rt15
- 6f0d03aa base: linux-lmp: 6.1: bump to v6.1.54
- f83b0bac base: docker-credential-helper: Handle leading spaces