### PR TITLE
Bump meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="10e35371f797ec4fcf7da55e954c5209b90fee2d"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="2fbc3e9681788513d03868def85188a148b763e2"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2d08d6bf376a1e06c53164fd6283b03ec2309da4"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="a88cb922f91fda95e8a584cee3092083d5ad3e98"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="faa80fa60c3b39e0a7c9b7817e28a2e7ff33010f"/>


### PR DESCRIPTION
Relevant changes:

- 2fbc3e96 base: u-boot-fio: beaglebone-yocto: fix FIT_SIGNATURE options
- 5d72d452 base: u-boot: rename common base and ebbr configs
- c924a443 base: u-boot-fio: collect FIT_SIGNATURE options in common configs
- d6f800d5 base: u-boot-fio: reduce boot delay for unsigned u-boot
- a3ee3088 base: u-boot: introduce common base and common ebbr configs
- 1fdd7b68 base: rs: aktualizr: Bump aklite ver to 2afacef
- 6eed5505 base: u-boot-fio: imx-2022.04: bump to 605d0aa5c0
- c398066e tpm2-tss: fix Upstream-Status of patch
- c38f1fca bsp: u-boot-ostree-scr-fit: imx8mn: switch to alternative
- 94157620 bsp: u-boot-fio: imx8mn: fix CONFIG_SECONDARY_BOOT_SECTOR_OFFSET
- a44b69a5 bsp: u-boot-ostree-scr-fit: imx8mp-lpddr4-evk: switch to alternative
- a406b894 bsp: u-boot-fio: imx8mp: fix CONFIG_SECONDARY_BOOT_SECTOR_OFFSET
- 0212c570 bsp: dynamic-layers: imx-atf: drop invalid patches