### PR TITLE
lmp-base: update openembedded-core layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -17,5 +17,5 @@
   <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="9f7fe77932671751f3c7201d164ffbabd0cb2faf"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="9e1ba07385017590f3d83e1deec8039359a55015"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="bca43f95850d395f9dc56644fa1d12910cabb0c5"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="2572b32e729831762790ebfbf930a1140657faea"/>
 </manifest>


### PR DESCRIPTION
Relevant changes:
- 2572b32e72 apt: add missing <cstdint> for uint16_t
- 27a1de55a4 python3-urllib3: 1.26.15 -> 1.26.17
- a335ccbcc9 python3-urllib3: upgrade 1.26.14 -> 1.26.15
- aefb7af6b5 python3-urllib3: upgrade 1.26.13 -> 1.26.14
- e8ae324779 python3-urllib3: upgrade 1.26.12 -> 1.26.13
- 69a610b440 python3-urllib3: upgrade 1.26.11 -> 1.26.12
- d83b4afc17 python3-urllib3: upgrade 1.26.10 -> 1.26.11
- d9f200b931 python3-urllib3: upgrade 1.26.9 -> 1.26.10
- 6c88137d4a vim: Upgrade 9.0.1894 -> 9.0.2009
- b2fa5b2946 binutils: Fix CVE-2022-45703
- 7a42ae332e binutils: Fix CVE-2022-44840
- fc4eecb614 xdg-utils: Fix CVE-2022-4055
- 1effa609b5 libtiff: fix CVE-2022-40090 improved IFD-Loop handling