### PR TITLE
lmp-base: update meta-lmp layer: u-boot 2023.04

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="cb51e30356c87db409499c7934da131e5cb1409c"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="ab6bdc7737ef7bf95b6c03c0211b502b09990ae4"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2d08d6bf376a1e06c53164fd6283b03ec2309da4"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="9c5541f7e18a1fac3b8dea71e1ebb8398d58e6ff"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="faa80fa60c3b39e0a7c9b7817e28a2e7ff33010f"/>


### PR DESCRIPTION
Besides other changes, this update switches imx boards to use u-boot imx-2023.04.
      
Relevant changes:
- ab6bdc77 bsp: u-boot-fio: imx6ul/imx6ull: enable boot firmware info
- 659945a5 bsp: u-boot-fio: imx6ul/imx6ull: restore config options
- f913c688 bsp: imx: update u-boot imx-2023.04 override to be nxp-bsp based
- af8f3329 base: u-boot-fio/mfgtool: disable CONFIG_BOOTSTD
- 501307ff bsp: u-boot-fio: rename options renamed in 2023.04
- 6dc4280c bsp: stm32mp1: disable build of alsa-state-stm32mp1
- 22dc1d64 bsp: lmp-mfgtool: stm32mp1: provide specific machines for layout vars
- 75d13589 bsp: stm32mp1: use softer asigments for flashlayout vars
- 74aaedcd bsp: dynamic-layers: stm32-mfgtool-files: use lazy assigments
- 1c17139b bsp: stm32mp1: discard build of stm32mp157f device trees
- 0d5ea3f1 base: distro: add gcc and libdrm to bbmask
- 9986c696 base: layer.conf: override compat for stm-st-stm32mp
- e2a2cc58 bsp: tegra: linux-tegra-rt: bump to r35.4.ga
- 03e341be bsp: u-boot-fio-mfgtool: imx8mp-lpddr4-evk: switch u-boot to imx-2023.04
- 7c08116f bsp: u-boot-fio: imx8mp-lpddr4-evk: switch u-boot to imx-2023.04
- d0181ed6 base: u-boot-fio: imx-2023.04: bump to 52852747ff3
- e29982a2 bsp: imx8mp-lpddr4-evk: add required dtb
- 02602871 bsp: u-boot-fio: imx93-11x11-lpddr4x-evk: switch u-boot to imx-2023.04
- 9ec4d273 bsp: u-boot-fio-mfgtool: imx93-11x11-lpddr4x-evk: switch u-boot to imx-2023.04
- beb5f963 bsp: u-boot-fio: imx8qm-mek: switch u-boot to imx-2023.04
- bff3971b bsp: u-boot-fio-mfgtool: imx8qm-mek: switch u-boot to imx-2023.04
- 084dfe23 bsp: u-boot-fio: imx8mn-lpddr4-evk: switch u-boot to imx-2023.04
- 716efe0e bsp: u-boot-fio: imx8mq-evk: switch u-boot to imx-2023.04
- 106b1d3c bsp: u-boot-fio-mfgtool: imx8mq-evk: switch u-boot to imx-2023.04
- 9c53bd2d bsp: u-boot-fio: imx8ulp-lpddr4-evk: switch u-boot to imx-2023.04
- 7a676d09 bsp: u-boot-fio-mfgtool: imx8ulp-lpddr4-evk: switch u-boot to imx-2023.04
- e7d1929e bsp: u-boot-fio: imx8mn-ddr4-evk: switch u-boot to imx-2023.04
- f9274914 bsp: u-boot-fio-mfgtool: imx8mn-[lp]ddr4-evk: switch u-boot to imx-2023.04
- d202b7c6 bsp: u-boot-fio: imx8mm-lpddr4-evk: switch u-boot to imx-2023.04
- 722bc6de bsp: u-boot-fio-mfgtool: imx8mm-lpddr4-evk: switch u-boot to imx-2023.04
- 6168164f bsp: u-boot-fio: imx6ullevk: switch u-boot to imx-2023.04
- f2d28abf bsp: u-boot-fio-mfgtool: imx6ullevk: switch u-boot to imx-2023.04
- 71b9f6d4 bsp: u-boot-fio: imx6ulevk: switch u-boot to imx-2023.04
- f53347cc bsp: u-boot-fio-mfgtool: imx6ulevk: switch u-boot to imx-2023.04
- 0c088770 base: u-boot-fio: common: disable VIDEO
- dafb1b86 base: u-boot-fio-mfgtool: common: disable VIDEO
- 9d079fc7 base: u-boot-fio: imx-2023.04: bump to ff08e43ab0b