### PR TITLE
lmp-bsp: update meta-st-stm32mp layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update \
 		make patch repo sudo texinfo vim-tiny wget whiptail libelf-dev git-lfs screen \
 		socket corkscrew curl xz-utils tcl libtinfo5 device-tree-compiler python3-pip python3-dev \
 		tmux libncurses-dev vim zstd lz4 liblz4-tool libc6-dev-i386 \
-		awscli docker-compose gosu xvfb python3-cairo python3-gi-cairo yaru-theme-icon \
+		awscli docker-compose gosu xvfb python3-cairo python3-gi-cairo yaru-theme-icon tree rsync \
 	&& ln -s /usr/bin/python3 /usr/bin/python \
 	&& pip3 --no-cache-dir install expandvars jsonFormatter \
 	&& apt-get autoremove -y \

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -10,7 +10,7 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="b3be00d8c8cd80d89b04b4dc81bf008025d0c53a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="12154d59fd0c5eec7911a66e0b56e70104346823"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="43683cb14b6afc144619335b3a2353b70762ff3e"/>
-  <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="b9ac4cf691e35819c29d5a85c23d51b91ce529dc"/>
+  <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="6d84bde08c03ec0184af08c2d3875fe5a334587e"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="8b50fe692a24a80b5c3cd1f816bcdd3e0b00418a"/>
   <project name="meta-xilinx" path="layers/meta-xilinx" remote="fio" revision="f8d8efab12040712df32436643621b2756de1f76"/>
   <project name="meta-xilinx-tools" path="layers/meta-xilinx-tools" remote="fio" revision="9acf9d1d02f465b3c435283f92557b632becc72a"/>


### PR DESCRIPTION
```
Relevant changes:
- 6d84bde LINUX-STM32MP: stm32-mdma: correct desc prep when channel running
- b355e07 LINUX-STM32MP: v6.1-stm32mp-r1.1
- dd2ea50 OPTEE-OS-STM32MP: 3.19.0-stm32mp-r1.1
- 174f6ea U-BOOT-STM32MP: v2022.10-stm32mp-r1.1
- 3c45ecf TF-A-STM32MP: v2.8-stm32mp-r1.1
- 6e10f6b GCNANO-USERLAND: add libglesv3 standalone package
- 6a3f150 GCC-ARM-NONE-EABI: update to 11.3
```