### PR TITLE
lmp-base: update meta-lts-mixins-go layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="647b7d355cda380eafacf79f71b0aafb6a387cc4"/>
   <project name="meta-clang" path="layers/meta-clang" revision="79169d9be565b7a87310ca280d3a21aaf608ce33"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="8a75c61cce2aa1d6e5a3597ab8fc5a7e6aeae1e4"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="faa80fa60c3b39e0a7c9b7817e28a2e7ff33010f"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="a0384aea22a3ddfc70202a26ee1372c91b1fcfc9"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="6b3a208f7e14138728a6e581ac75e8973ab48ef3"/>
   <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="9f7fe77932671751f3c7201d164ffbabd0cb2faf"/>


### PR DESCRIPTION
Relevant changes:
- a0384ae go: update 1.20.11 -> 1.20.12
- ee01e3e go: update 1.20.10 -> 1.20.11