### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="647b7d355cda380eafacf79f71b0aafb6a387cc4"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="165b620a7eb591b0483d8f63babfac6756fad909"/>
   <project name="meta-clang" path="layers/meta-clang" revision="79169d9be565b7a87310ca280d3a21aaf608ce33"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="8a75c61cce2aa1d6e5a3597ab8fc5a7e6aeae1e4"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="faa80fa60c3b39e0a7c9b7817e28a2e7ff33010f"/>


### PR DESCRIPTION
Relevant changes:
- 165b620a7 bsp: linux-lmp: stm32mp15-disco: add patch to auto enable i2c5 with se05x
- 38ccbc620 base: rs: aktualizr: bump version to f290020
- e3f0a9df1 base: rs: custom-sota-client: Add User to Unit file
- b97d26704 bsp: dynamic-layers: imx-atf: adjust power off logic
- 02cb459d5 base: rs: aktualizr: bump to 6137b8a
- 5fbff53cc base: rs: Remove app register from app early start
- b924dc43b base: mxm-mwifiex-setup: fix moal parameters