### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="0724ff11b6cec61e385a65deaafb8e834585aff4"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="c34e368ef6842fe5c083d2280b96334c82ad6a71"/>
   <project name="meta-clang" path="layers/meta-clang" revision="79169d9be565b7a87310ca280d3a21aaf608ce33"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="8a75c61cce2aa1d6e5a3597ab8fc5a7e6aeae1e4"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="a0384aea22a3ddfc70202a26ee1372c91b1fcfc9"/>


### PR DESCRIPTION
Relevant changes:
- c34e368e base: u-boot-fio: lmp-common.cfg: disable CONFIG_ENV_MMC_USE_DT
- 1e1897d0 bsp: wic: stm32mp1: wks file improvements
- ffe4e660 base: optee-os-fio: 3.21: bump to 33d9bf3fc
- 6aa7cc6f bsp: optee-os-fio-bsp: increase heap size to 128k
- 5ddf3817 bsp: imx-boot: refresh patches
- 273f8c44 bsp: tf-a-fio-st: check the signing tool instaed of the path
- bee277f9 bsp: tf-a-fio-st: run the signing tool in silent mode
- 32ff2c59 bsp: tf-a-fio-st: drop the STM32_ROT_KEY_PATH/STM32_ROT_KEY_PASSWORD check
- 0ac284e9 bsp: tf-a-fio-st: run the sign_binaries using a postfuncs