### PR TITLE
setup-environment-internal: don't propagate the LMP_VERSION_CACHE

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -273,6 +273,9 @@ INHERIT += "buildhistory"
 BUILDHISTORY_COMMIT = "1"
 EOF
 
+# we don't need this anymore
+unset LMP_VERSION_CACHE
+
 if [ ! -e conf/site.conf ]; then
     cat > conf/site.conf <<_EOF
 SCONF_VERSION = "1"


### PR DESCRIPTION
The problem it fixes is because after the first run of the source setup-environment, the variable LMP_VERSION_CACHE was created in the current shell. Then the following calls of
source setup-environment will use what is on that variable and forces the cache version infered in the first run.