### PR TITLE
lmp-base: update openembedded-core layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -17,5 +17,5 @@
   <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="3473dc7c88a16cea2e9a6365e22c2331464078f1"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="88327090d26955a678c6f8bd2585aad4d802f6c4"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="ebd61290a644a6d9f2b3701e0e7ea050636da76c"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="ad696a0067e11c332a4542ccacd76455f5fbd984"/>
 </manifest>


### PR DESCRIPTION
Relevant changes:
- ad696a0067 xserver-xorg: Multiple CVE fixes
- 9af2e012ee pam: fix CVE-2024-22365 pam_namespace misses
- de74fd5dea gnutls: Fix for CVE-2024-0553 and CVE-2024-0567
- 0730806ae3 tiff: fix CVE-2023-6228
- 6bb64af6ce openssl: fix CVE-2023-6237 Excessive time spent checking invalid RSA public keys
- 626711a95f dropbear: backport patch for CVE-2023-48795