### PR TITLE
Update Rust from 1.68.2 to 1.74.1

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -13,7 +13,7 @@
   <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="730e44900a0a86265bad93a16b5a5ff344a07266"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="a0384aea22a3ddfc70202a26ee1372c91b1fcfc9"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="6b3a208f7e14138728a6e581ac75e8973ab48ef3"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="ead509ebe28cb9b588d401c5f254159cd6c5d39a"/>
   <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="3473dc7c88a16cea2e9a6365e22c2331464078f1"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="88327090d26955a678c6f8bd2585aad4d802f6c4"/>


### PR DESCRIPTION
Populate kirkstone/rust branch (cover letter only)
```
As discussed on the last couple of YP technical calls, I have created
a kirkstone/rust branch in meta-lts-mixins.  It backports the state of
As discussed on the last couple of YP technical calls, I have created
a kirkstone/rust branch in meta-lts-mixins.  It backports the state of
Rust support in master to kirkstone (so currently 1.74.1) the same way
that the previous kirkstone/rust-1.68 and kirkstone/rust-1.70 branches
did against mickledore and nanbield.  The aim with kirkstone/rust is to
keep it up to date with the level of Rust support in master until the
Kirkstone EOL in April 2026.

The majority of the patches listed below were manually picked from
master and adapted on top of the kirkstone/rust-1.70 branch to create
this new branch.  If you would like to look at the changes in detail,
they are browsable at:

https://git.yoctoproject.org/meta-lts-mixins/log/?h=kirkstone/rust
```

https://lists.yoctoproject.org/g/yocto/message/62278