### PR TITLE
lmp-base: update meta-lts-mixins-go layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="649cfaa47f454741333bc9f0533a72f0771310c0"/>
   <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="730e44900a0a86265bad93a16b5a5ff344a07266"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="a0384aea22a3ddfc70202a26ee1372c91b1fcfc9"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="693179205e27cb697a7afd60b75f81063424f3a9"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="ead509ebe28cb9b588d401c5f254159cd6c5d39a"/>
   <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="3473dc7c88a16cea2e9a6365e22c2331464078f1"/>


### PR DESCRIPTION
Relevant changes:
- 6931792 go: update 1.20.12 -> 1.20.13