### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="649cfaa47f454741333bc9f0533a72f0771310c0"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7b50a9d0b355ce0bf722e4bf5a8f9ff42a3100db"/>
   <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="730e44900a0a86265bad93a16b5a5ff344a07266"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="693179205e27cb697a7afd60b75f81063424f3a9"/>


### PR DESCRIPTION
Relevant changes:
- 7b50a9d0b base: linux-lmp-rt: 6.1: bump to v6.1.75-rt23
- bcbc9c6c9 base: linux-lmp: 6.1: bump to v6.1.75
- 10c75a272 bsp: u-boot-ti-staging: am62xx-evm: load boot.itb from eMMC
- 23a760793 base: docker: update to v25.0.2
- 541877bce base: containerd-opencontainers: update to 1.7.13
- c401b7f77 base: runc-opencontainers: update to 1.1.12
- c0eaf0a0e base: aktualizr-callback: move to the correct base layer folder
- 227b7b805 bsp: u-boot-ti-staging: am62xx-evm: load env from eMMC
- 270fc22ca bsp: u-boot-ostree-scr-fit: am62xx-evm: boot from eMMC
- 127c7f0c3 base: lmp: bump version for the 4.0.16 yocto release
- b696ba3b8 base: correct aktualizr-callback RDEPENDS
- 6f3cdedf8 base: aktualizr-callback: add a callback handler example
- 294c68438 base: fioconfig: Bump version
- d217c3329 bsp: tegra-helper-scripts: update initrd-flash.sh fork with lastest changes
- 890c51948 bsp: stm32-mfgtool-files drop unused STM32_BOOTIMAGE_SUFFIX