### PR TITLE
lmp-bsp: update meta-intel layer

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -8,7 +8,7 @@
   <project name="meta-arm" path="layers/meta-arm" revision="b187fb9232ca0a6b5f8f90b4715958546fc41d73"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="0a73d1bdd7713a6189482e463c98043c9939a2a2"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="7725256e3859b62f1ff201db7f2cf7026c17656d"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="f932ebb2544170f43edd22739f44307809bf8cfb"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="1bca60610c597571769edc4a057a04bfdbd2f994"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="43683cb14b6afc144619335b3a2353b70762ff3e"/>
   <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="b0af85c466d96d5f794b125b2542b7a0ea4c91de"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="77c2830ae0c3e7370f7c816796981932ba0ec99a"/>


### PR DESCRIPTION
Same revision as used by
https://github.com/intel/iotg-yocto-ese-manifest/releases/tag/release-145_rpl_s-mr2.

Relevant changes:
- 1bca6061 linux-intel-rt/6.1: update to v6.1.46-rt14
- c139b27c linux-intel/6.1: update to v6.1.46
- dc5a3429 intel-media-driver: Fix corruption issue for no background colorfill cases
- 6883d43a onednn: upgrade 3.2.1 -> 3.3
- e68a4072 intel-crypto-mb: upgrade 2021.8 -> 2021.9.0
- e35d6804 meta-intel.inc: use the correct version of opencl-clang
- 36171452 opencl-clang: drop upstreamed patch
- 086552f6 openvino-inference-engine: fix multilib build
- 6a3d314f linux-intel-rt/6.4: set LINUX_KERNEL_TYPE
- 4ec7fc95 embree: upgrade 4.2.0 -> 4.3.0
- 4e94f057 openvino-model-optimizer: upgrade 2023.0.1 -> 2023.1.0
- d04382d3 open-model-zoo: upgrade 2023.0.1 -> 2023.1.0
- f9cb1d9a openvino-inference-engine: upgrade 2023.0.2 -> 2023.1.0
- cc04677a intel-media-driver: Fix pixelation issue on multiple input direct write operation
- a89e233e layer.conf: update LAYERSERIES_COMPAT to use nanbield
- 0ccbd5e7 intel-media-driver: fixed multi issues
- c9c5b8b1 openvino-inference-engine: upgrade 2023.0.1 -> 2023.0.2
- a1ac7dc5 intel-oneapi-ipp: disable INHIBIT_DEFAULT_DEPS
- df09fd9f onednn: upgrade 3.2 -> 3.2.1
- f2513488 intel-cmt-cat: upgrade 4.6.0 -> 23.08
- a9329d49 ixgbevf : upgrade 4.17.11 -> 4.18.7
- 110eb064 thermald: upgrade 2.5.3 -> 2.5.4
- 096eccc8 metrics-discovery: upgrade 1.12.165 -> 1.12.165.1
- 70179607 embree: upgrade 4.1.0 -> 4.2.0
- 5f9c566d ixgbe : upgrade 5.18.11 -> 5.19.6
- f1b42ef7 backport-iwlwifi: upgrade core45 -> core79
- 2e068767 vc-intrinsics: drop recipe
- 042249ca openvino: use SRCREV_FORMAT
- 27b72d85 ipmctl: use SRCREV_FORMAT
- a4d0a75b intel-oneapi-mkl: dont check for debian renaming of packages
- 06853378 ispc: upgrade 1.20.0 -> 1.21.0
- 7368b965 intel-mediasdk: upgrade 23.2.1 -> 23.2.2
- fd3878ea onevpl-intel-gpu: upgrade 23.1.5 -> 23.2.4
- c29299d2 onevpl: upgrade 2023.1.3 -> 2023.3.0
- 0a8af9c9 intel-media-driver: upgrade 23.1.6 -> 23.2.4
- f0aef0ce libva-intel-utils: upgrade 2.18.1 -> 2.19.0
- 84d6fcd0 libva-intel: upgrade 2.18.0 -> 2.19.0
- b35fca58 gmmlib: upgrade 22.3.5 -> 22.3.7
- 4bf5828c intel-microcode: upgrade 20230512 -> 20230808
- 1463e5ae linux-intel/6.4: change kernel cache branch to yocto-6.4
- 791c5056 linux-intel-rt/6.4: add recipe
- 711eee2b opencl-clang: move common code to inc
- efd8310c opencl-clang/14.0: update to latest
- d9d4392e opencl-clang/15.0: update to latest
- ed119ed7 intel-compute-runtime : upgrade 23.17.26241.22 -> 23.22.26516.18
- 69a52669 intel-graphics-compiler : upgrade 1.0.13822.6 -> 1.0.14062.11
- e2d14028 thermald : upgrade 2.5.2 -> 2.5.3
- 311a4fa8 intel-crypto-mb : upgrade 2021.7.1 -> 2021.8
- dc3e3fac conf/machine: set preferred kernel to 6.4 for poky-altcfg
- 75d2e2cf linux-intel/6.4: add recipe
- f2bcad29 linux-intel-rt/6.1: update to tag lts-v6.1.38-rt12-preempt-rt-230713T145506Z
- c5d1a621 linux-intel/6.1: update to tag lts-v6.1.38-linux-230713T130532Z
- f96c815a intel-oneapi-dpcpp-cpp: upgrade 2023.0.0-25370 -> 2023.1.0-46305
- 99eac751 intel-oneapi-dpcpp-cpp-runtime: upgrade 2023.0.0-25370 -> 2023.1.0-46305
- 8af19995 intel-compute-runtime: use qemu to run native binaries
- 4f5cc7a0 intel-graphics-compiler: use qemu to run native binaries
- dab85c23 intel-compute-runtime: upgrade 23.13.26032.30 -> 23.17.26241.22
- 25884a18 intel-graphics-compiler: upgrade 1.0.13700.14 -> 1.0.13822.6
- 024ff7f7 ospray : upgrade 2.11.0 -> 2.12.0
- e965b632 onednn : upgrade 3.1 -> 3.2
- ba750966 metrics-discovery : upgrade 1.12.164 -> 1.12.165
- ccd27655 libipt : upgrade 2.0.5 -> 2.0.6
- 614d4285 itt : upgrade 3.24.0 -> 3.24.2
- 579d21af open-model-zoo : upgrade 2023.0.0 -> 2023.0.1
- e0686afa openvino-model-optimizer : upgrade 2023.0.0->2023.0.1
- 7515d740 openvino-inference-engine: upgrade 2023.0.0 -> 2023.0.1
- 1bf13960 lms: fix installation path for udev rules
- 3250a33f sbsigntool: fix Upstream-Status format
- 34b65b71 hdcp: fix Upstream-Status format
- 73c6e796 Revert "lms: fix build with usrmerge DISTRO feature"
- 759754c0 security.md: document security policy and reporting guideline
- 91a2562f sbsigntool-native: fix SRCREV
- bd2c921f lms: fix build with usrmerge DISTRO feature
- a1ae00c7 onevpl: dont pass pcfiledir to cflags
- 046a0f48 intel-cmt-cat: upgrade 4.5.0 -> 4.6.0
- 4be9abda sbsigntool-native: upgrade to 0.9.5
- 2249cab0 onevpl-intel-gpu: add RDEPEND on intel-media-driver
- 7710b82c intel-media-driver: Fix H265 SCC encode failure.
- 9fa42594 intel-crypto-mb: fix multilib build
- a4991839 openvino-inference-engine: use protobuf as a submodule
- 3c367f25 ispc: upgrade 1.19.0 -> 1.20.0
- dbc3ac30 open-model-zoo: upgrade 2022.2.0 -> 2023.0.0
- 0444a0b3 openvino-model-optimizer: upgrade 2022.3.0 -> 2023.0.0
- 34851110 openvino-inference-engine: upgrade 2022.3.0 -> 2023.0.0
- eb696e99 onevpl-intel-gpu: Disable CM COPY for ADL-P and RPL-P.
- d7692dba onevpl: fix various issues
- 43a28a83 metrics-discovery: upgrade 1.12.163 -> 1.12.164
- 2b31910c level-zero: upgrade 1.7.15 -> 1.11.0
- dc5c9fb1 intel-crypto-mb: upgrade 2021.6 -> 2021.7.1
- 8220eccb openvino-inference-engine: fix build with gcc13
- c8fc88b7 intel-compute-runtime: fix build with gcc13
- 1340aeb6 intel-compute-runtime: upgrade 23.09.25812.14 -> 23.13.26032.30
- b533ec1e intel-graphics-compiler: upgrade 1.0.13463.18 -> 1.0.13700.14
- e7ef2895 linux-intel-rt/6.1: add recipe
- 92ed65a3 lms: fix build errors with gcc13
- 2f54f351 ispc: fix build with gcc13
- 277f7f78 intel-media-driver: fix build with gcc13
- 068182db intel-mediasdk: fix build with gcc13
- 5b78a9af onevpl-intel-gpu upgrade: 22.6.5 -> 23.1.5
- 63149cac onevpl upgrade: 2023.1.1 -> 2023.1.3
- 717b0e7a intel-mediasdk upgrade: 22.6.5 -> 23.2.1
- 54383bd3 intel-media-driver: upgrade 23.1.0 -> 23.1.6
- 871317ec libva-intel-utils: upgrade 2.17.1 -> 2.18.1
- dd356eb9 libva-intel: upgrade 2.17.0 -> 2.18.0
- 717ccd37 intel-gmmlib: upgrade 22.3.3 -> 22.3.5
- f08c93b2 thermald: depend on autoconf-archive-native
- a0ea4e5d intel-microcode: upgrade 20230214 -> 20230512
- dc19c9bb embree: upgrade 4.0.1 -> 4.1.0
- 93d65148 linux-intel-rt/5.19: update to tag mainline-tracking-v5.19-rt10-preempt-rt-230407T052642Z
- a76e24f0 linux-intel/6.1: update to tag lts-v6.1.26-linux-230504T201607Z
- ca9fa7a5 linux-intel/6.2: update to tag mainline-tracking-v6.2-linux-230419T060611Z,
- edf80dea ispc: fix recipe
- 2752b2e2 onevpl: fix onevpl-examples packaging
- bd2c1b6b ipmctl : upgrade 03.00.00.0483 -> 03.00.00.0485
- 6f552203 intel-graphics-compiler: upgrade 1.0.13230.7 -> 1.0.13463.18
- 0b3f1562 intel-compute-runtime: upgrade 23.05.25593.11 -> 23.09.25812.14
- 48ddf2b0 onednn: upgrade 3.0.1 -> 3.1
- 51b86cf2 intel-compute-runtime: upgrade 22.49.25018.24 -> 23.05.25593.11
- aed4bb9a intel-graphics-compiler: upgrade 1.0.12812.24 -> 1.0.13230.7
- ef15b09a linux-intel-rt/5.19: update to tag mainline-tracking-v5.19-rt10-preempt-rt-230316T223733Z
- 96c0c9d5 linux-intel/6.2: update to tag mainline-tracking-v6.2-linux-230308T061118Z
- f590e657 linux-intel/6.1: update to tag lts-v6.1.12-linux-230316T132124Z
- dc066aa4 onedpl: upgrade 2021.7.0 -> 2022.0.0
- 631c016f maintainers.inc: include entry for intel-cmt-cat
- ec3147ab intel-cmt-cat: add recipe
- b81ad5eb openvino: fix UPSTREAM_CHECK_GITTAGREGEX
- 2b37e2a6 openvkl: disable avx ISAs for intel-corei7-64 machine
- c88dfd9a itt: upgrade 3.23.0 -> 3.24.0
- fc1d35e1 lms: upgrade 2226.0.0.0 -> 2245.0.0.0
- 8a7f46aa ipmctl : upgrade 03.00.00.0468 -> 03.00.00.0483
- e27e988f onednn: upgrade 3.0 -> 3.0.1
- dfd14a16 metrics-discovery : upgrade 1.12.158 -> 1.12.163
- ae595644 intel-oneapi-ipp: install headers
- 8734c6a0 openvino-inference-engine: add PACKAGECONFIG for samples
- c420e9fc openvino-inference-engine: remove python3-opencv from DEPENDS
- 08c5a9be openvino-inference-engine: Use external gflags
- 476275e9 ospray: upgrade 2.10.0 -> 2.11.0
- a2657c7c openvkl: upgrade 1.3.0 -> 1.3.2
- ca45e345 embree: upgrade 3.13.5 -> 4.0.1
- 327be147 rkcommon: upgrade 1.10.0 -> 1.11.0
- 48e5fcbf jhi: remove recipe and test
- e338dcb7 openvino: fix UPSTREAM_CHECK_GITTAGREGEX
- 9b29afcd intel-mediasdk: Fix build dependency
- 647c36eb openvino-inference-engine: Fix build dependency
- f3f48ac8 intel-oneapi-mkl: Fix runtime dependency
- 1be38ea8 intel-oneapi-dpcpp-cpp-runtime: Fix runtime dependency
- 1305a9fa intel-oneapi-compiler: Fix runtime dependency
- b398300a onednn: Fix build dependency
- ba3ac217 conf/machine: set preferred kernel to 6.2 for poky-altcfg
- 503e4e56 linux-intel/6.2: add recipe
- 197effab onednn: upgrade 2.7.1 -> 3.0
- 5f2a109a ispc: upgrade 1.18.0 -> 1.19.0
- 3289c1c6 intel-compute-runtime: upgrade 22.38.24278 -> 22.49.25018.24
- 9302542e igc: add patch upstream status
- 4a5cfd35 intel-graphics-compiler: upgrade 1.0.12812.9 -> 1.0.12812.24
- d5ddfa03 thermald: upgrade 2.5.1 -> 2.5.2
- 4bd0fb45 ixgbevf: upgrade 4.16.5 -> 4.17.11
- b605f173 openvino-model-optimizer: update to latest from 2022.3 branch
- 1790fd8d openvino-inference-engine: update to latest on 2022.3 branch
- cba5ffa6 ixgbe: upgrade 5.17.1 -> 5.18.11
- 0dd3e3d6 xf86-video-ast : upgrade 1.1.5 -> 1.1.6
- c8ffd392 openvino-model-optimizer: upgrade 2022.2.0 -> 2022.3.0
- fe69a947 meta-intel.inc: build v6.1 kernel with poky distro
- 03229249 linux-intel/5.15: remove recipes
- 533b604a linux-intel/6.1: add recipe
- 31f67cc9 intel-microcode: upgrade 20221108 -> 20230214
- 57a3810e linux-intel-rt/5.19: update to tag mainline-tracking-v5.19-rt10-preempt-rt-230104T115537Z
- 82cb65cf linux-intel/5.19: update to tag mainline-tracking-v5.19-linux-230118T042554Z
- 53df30ef linux-intel-rt/5.15: update to tag lts-v5.15.85-rt55-preempt-rt-230113T035939Z
- 434d4648 linux-intel/5.15: update to tag lts-v5.15.85-linux-230113T035248Z
- 3e2a3aff onevpl-intel-gpu: upgrade 22.5.4 -> 22.6.5
- 6a6f0607 onevpl: upgrade 2022.2.2 -> 2023.1.1
- d6eec557 intel-mediasdk: upgrade 22.6.0 -> 22.6.5
- d4bba3cc intel-media-driver: upgrade 22.5.4 -> 23.1.0
- 15c9cc79 libva-intel-utils: upgade 2.16.0 -> 2.17.1
- 535790ae libva-intel: upgrade 2.16.0 -> 2.17.0
- fe0c4e64 intel-gmmlib: upgrade 22.2.0 -> 22.3.3
- a70f7826 linux-yocto: make the bbappend generic
- 9663e584 linux-yocto: allow building 6.1 linux-yocto kernel with meta-intel
- cc3b4ed7 intel-oneapi-dpcpp-cpp-runtime: install missing common headers
- b3c7d3ee intel-oneapi-mkl: install missing headers
- e99ca0c5 recipes: fix Upstream-Status tags
- a9242002 openvino-inference-engine: fix multilib build
- e99756e0 intel-graphics-compiler: ignore buildpaths warning
- b15d2fbc openvino-inference-engine: upgrade 2022.2.0 -> 2022.3.0
- 7d7aaa08 intel-graphics-compiler: fix buildpaths warnings
- 1ef50594 intel-oneapi-ipp: upgrade 2021.5.1-522 -> 2021.7.0-25396
- 0649e856 intel-oneapi-dpcpp-cpp: upgrade 2022.1.0-3768 -> 2023.0.0-25370
- 046726f8 intel-oneapi-dpcpp-cpp-runtime: upgrade 2022.1.0-3768 -> 2023.0.0-25370
- 7eff6284 intel-oneapi-mkl: upgrade 2022.0.1-117 -> 2023.0.0-25398
- 731985dc setup-intel-oneapi-env: rename 2022.0.1-3633 -> 2023.0.0-25370
- 19400ed8 intel-oneapi-compiler: upgrade 2022.0.1-3633 -> 2023.0.0-25370
- 423820af intel-skylake-64: use tune-x86-64-v3.inc
- 9595cf0e layer.conf: update LAYERSERIES_COMPAT to include mickledore
- 7f8e1c53 tune-skylake.inc: remove qemu-usermode check
- 66d1397b layer.conf: remove addpylib directive
- bc021ab0 layer.conf: use addpylib directive
- c7c8ed43 linux-intel/5.15: fix upstream release checking
- 3ccb7aaf meta-intel.inc: add r8152 kernel module to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS
- fda41086 meta-intel.inc: add igc module to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS
- 1153290b ispc : Add ptest
- 6ca9a5cb linux-intel/5.19: fix upstream release checking
- d72944f1 intel-graphics-compiler: refresh patches
- de59d48a intel-graphics-compiler: fix build issues with LLVM12
- d01bcf87 intel-graphics-compiler: upgrade 1.0.12149.1 -> 1.0.12812.9
- f9e2e05f dpcpp-compiler.md: add document for icx installation
- 18fcf499 sdk: Add support for adding icx to SDK
- 2c58fe08 icc: drop Intel C++ classic compiler support
- 555a2f97 intel-oneapi-dpcpp-cpp: add Intel(R) oneAPI DPC++/C++ Compiler
- c4aa7363 meta-intel.inc: set default PREFERRED_VERSION to 5.19 kernel
- 6d976ec8 linux-intel-dev: drop recipe
- 579394dc linux-intel-rt/5.19: add recipe
- 2ce9b55f linux-intel/5.19: add recipe
- 585655e5 setup-intel-oneapi-env: add native and nativesdk to BBCLASSEXTEND
- ce15d6f6 level-zero: add native and nativesdk to BBCLASSEXTEND
- 4a346976 thermald: upgrade 2.5.0 -> 2.5.1
- cfff031e ixgbe: upgrade 5.16.5 -> 5.17.1
- 36995675 intel-microcode: upgrade 20220809 -> 20221108
- a230cd15 onednn : upgrade 2.6.2 -> 2.7.1
- b74ec777 metrics-discovery : upgrade 1.5.108 -> 1.12.158
- a09b3264 linux-intel-rt/5.15: update to v5.15.71
- d85104f1 linux-intel/5.15: update to v5.15.71
- 2db6c8af linux-intel: fix perf reproducibility
- 65e67f01 openvino-inference-engine: update pybind11
- 94b628a3 intel-mediasdk: upgrade 22.4.4 -> 22.6.0
- ec8e3078 onevpl-intel-gpu: upgrade 22.4.4 -> 22.5.4
- 2c470395 onevpl: upgrade 2022.1.5 -> 2022.2.2
- d58079dd intel-media-driver: upgrade 22.5.3 -> 22.5.4
- 9879db3a libva-intel-utils: upgrade 2.15.0 -> 2.16.0
- 6c5cf6da libva-intel: upgrade 2.15.0 -> 2.16.0
- 8b6e380c gmmlib: upgrade 22.1.4 -> 22.2.0
- 323fee2c vc-intrinsics: update to latest
- 7dffd823 opencl-clang/15.0.0: add recipe
- 7023a6d7 openvino-model-optimizer: upgrade 2022.1.1 -> 2022.2.0
- 46be0fa9 open-model-zoo: upgrade 2022.1.1 -> 2022.2.0
- 023266fc openvino-inference-engine : upgrade 2022.1.1 -> 2022.2.0
- 5963592b iccsdk: install icc specific packages only for meta-intel machines
- f7cbf66e sdk: Add support for adding icc to SDK
- 6e5caa63 icc: add Intel(R) C++ Compiler Classic (ICC) support
- 3217386e ispc: fix file-rdeps
- 03a37ae3 README: update tested hardware list
- 0387793c onevpl-intel-gpu: fixed hevc decoding starvation issue
- 8a664853 onevpl: fixed sample rendering failed in weston10
- c4f1331c intel-media-driver: upgrade 22.4.4 -> 22.5.3
- 61a2e69d onevpl: Fix missing UYVY VA_FOURCC causing encode failure
- 940218bd layer.conf: add langdale to LAYERSERIES_COMPAT
- 819b6cf9 intel-graphics-compiler : upgrade 1.0.11702.1 -> 1.0.12149.1
- f77562ad intel-compute-runtime : upgrade 22.32.23937 -> 22.38.24278
- c2274194 onednn : upgrade 2.6.1 -> 2.6.2
- 1a593752 ipmctl : upgrade 03.00.00.0462 -> 03.00.00.0468
- 948757b8 embree : upgrade 3.13.4 -> 3.13.5
- ad81baa4 ispc: fix build with LLVM 15
- 3b6b2b88 intel-graphics-compiler: add nobranch=1 in SRC_URI
- 9d2820d4 intel-oneapi-mkl: Also allow MKL to be used via CMaake to compile other packages
- f51e1f33 intel-crypto-mb : upgrade 2021.5 -> 2021.6
- 2c6177f9 ixgbevf : upgrade 4.15.1 -> 4.16.5
- b0f5fba2 ixgbe : upgrade 5.15.2 -> 5.16.5
- c12abbd3 ipmctl : upgrade 03.00.00.0439 -> 03.00.00.0462
- 0337f4a8 intel-oneapi-mkl: Allow MKL to be used for compiling other packages
- b5664f2f open-model-zoo: upgrade 2021.1 -> 2021.1.1
- 54b3efbf openvino-model-optimizer: upgrade 2021.1 -> 2021.1.1
- d731daf5 openvino-inference-engine: upgrade 2022.1 -> 2022.1.1
- 87d4088e intel-compute-runtime: upgrade 22.31.23852 -> 22.32.23937
- 0a7687b2 Remove support for LLVM 12
- 94d6ec37 linux-intel-dev: update to 5.19.0
- 701d1dfe linux-intel-rt/5.15: update to v5.15.49
- 834291a2 linux-intel/5.15: update to v5.15.49
- cd174429 onednn: turn on PACKAGECONFIG for GPU engine
- 0f6e10d5 intel-microcode: upgrade 20220510 -> 20220809
- ecca0517 intel-compute-runtime: upgrade 22.23.23405 -> 22.31.23852
- a29a3b55 intel-microcode: update SRCREV for 20220510
- 50829fc9 openvino-inference-engine: enable GPU plugin
- cfef5f82 intel-graphics-compiler: upgrade 1.0.11378 -> 1.0.11702.1
- f21168e6 ipmctl: fix build issues with 5.18+ headers
- 789ff199 intel-mediasdk: fix dependencies
- fdde909d openvino-inference-engine: fix reproducibility issues
- 79486754 ospray : upgrade 2.9.0 -> 2.10.0
- 6eb22e64 openvkl : upgrade 1.2.0 -> 1.3.0
- 76042df2 embree : upgrade 3.13.3 -> 3.13.4
- 535b93e4 rkcommon : upgrade 1.9.0 -> 1.10.0
- 2914c71c ispc : upgrade 1.17.0 -> 1.18.0
- b783f9e9 intel-media-driver: upgrade 22.3.1 -> 22.4.4
- ada3eb57 thermald : upgrade 2.4.9 -> 2.5.0
- d615d325 onedpl : upgrade 2021.6.1 -> 2021.7.0
- 32d8fda8 ipmctl : upgrade 03.00.00.0438 -> 03.00.00.0439
- 97ac7b76 onednn : Upgrade 2.6 -> 2.6.1
- b83d01c6 lms : upgrade 2151.0.0.0 -> 2226.0.0.0
- c32dcde8 onevpl-intel-gpu: upgrade 22.3.2 -> 22.4.4
- b1e7cf60 onevpl: upgrade 2022.0.3 -> 2022.1.5
- 3bb460b6 intel-mediasdk: upgrade 22.3.0 -> 22.4.4
- d0a315c9 libva-intel-utils: upgrade 2.14.0 -> 2.15.0
- 6e9d38df libva-intel: upgrade 2.14.0 -> 2.15.0
- 6064de77 gmmlib: upgrade 22.1.2 -> 22.1.4
- de585189 linux-intel: fix buildpaths issue
- 0a96edae onevpl-intel-gpu: Fix HEVC 12 bit Encode
- 84b5cf24 slimboot-tools: update to latest commit
- bdcf0ec0 linux-intel: remove 32 bit specific tweaks
- 5ffac669 intel-compute-runtime: upgrade 22.22.23355 -> 22.23.23405
- 2f913cdb intel-graphics-compiler: upgrade 1.0.11279 -> 1.0.11378
- a499bad1 linux-intel/5.10: remove recipes
- 5184e1d8 ixgbe : upgrade 5.14.6 -> 5.15.2
- baa118e7 ixgbevf : upgrade 4.14.5 -> 4.15.1
- e9a69b0a linux-intel-rt/5.15: update to v5.15.43
- 70fa4a97 linux-intel/5.15: update to v5.15.43
- 66f4ff00 intel-compute-runtime: upgrade 22.11.22682 -> 22.22.23355
- 7cd06a4a intel-graphics-compiler: upgrade 1.0.10395 -> 1.0.11279
- c1674307 linux-intel-rt/5.10: update to v5.10.115
- 627c26ab linux-intel/5.10: update to v5.10.115
- df622318 openvino-inference-engine: change branch name master -> main
- ebb8c1c2 intel-compute-runtime: fix failures with gcc12
- 8dd90031 level-zero: remove devtool comments
- 2f1c8914 libxcam: fix narrowing warning due to GCC12
- 15324986 onevpl-intel-gpu: remove patch
- 45a43b1b ipmctl: fix build with gcc12
- 6d7dbf92 onevpl-intel-gpu: upgrade 22.1.0 -> 22.3.2
- f3a40c12 intel-mediasdk: upgrade 22.1.0 -> 22.3.0
- 81197e3b intel-media-driver: upgrade 22.1.1 -> 22.3.1
- 0346578f libva-intel-utils: upgrade 2.13.0 -> 2.14.0
- 479cea4d libva-intel: upgrade 2.13.0 -> 2.14.0
- 315e6d3f gmmlib: upgrade 22.0.3 -> 22.1.2
- e26d271f intel-microcode: upgrade 20220419 -> 20220510
- c1985735 maintainers.inc: add missing entry for vc-intrinsics
- e7adb4d1 ipp-crypto-mb: update to latest
- a678464d intel-graphics-compiler: define SRCREV_FORMAT
- 40814b43 onednn: upgrade 2.5.3 -> 2.6
- 2ec3b9e9 ipmctl: upgrade 03.00.00.0432 -> 03.00.00.0438
- 6c9d750d intel-microcode: upgrade 20220207 -> 20220419
- 04910866 metee: upgrade 3.1.2 -> 3.1.3
- a2f5f65c linux-intel-rt/5.10: update to v5.10.100
- c9e83043 linux-intel/5.10: update to v5.10.100
- 2c6ae10e linux-intel-rt/5.15: update to v5.15.31
- 2cba0c7b linux-intel/5.15: update to v5.15.31
- c49915bd ispc: disable build for Windows, android and other targets
- 4f8382d8 intel-oneapi-compiler: use ocl-icd instead of opencl-icd-loader
- b9da851f llvm-project-source: refresh patches
- 10944d53 intel-media-driver: fix build with gcc12
- 5e2b4c4a ixgbevf: upgrade 4.13.3 -> 4.14.5
- bbb42b19 ixgbe: upgrade 5.13.4 -> 5.14.6
- 316d40ce ipmctl: upgrade 03.00.00.0429 -> 03.00.00.0432
- f7cf423b level-zero: upgrade 1.7.9 -> 1.7.15
- 7980023e vc-intrinsics: update to latest
- f2534c55 open-model-zoo: upgrade 2021.4.2 -> 2022.1
- 01fa547c thermald: upgrade to v2.4.9
- b16a0636 openvino-model-optimizer: upgrade 2021.4.2 -> 2022.1
- ac72b03c openvino-inference-engine: upgrade 2021.4.2 -> 2022.1
- 23e680f9 libyami/libyami-utils: remove recipes