### PR TITLE
lmp-base: update meta-lts-mixins-rust layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -13,7 +13,7 @@
   <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="fda737ec0cc1d2a5217548a560074a8e4d5ec580"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="7b4c22b4114c5789a6cb7d8b0b7c7078cd9f0dc9"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="ead509ebe28cb9b588d401c5f254159cd6c5d39a"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="1a6746a81da4d5bf2e5640fd2fa8f3ea453d40bf"/>
   <project name="meta-security" path="layers/meta-security" revision="1a3e42cedbd94ca73be45800d0e902fec35d0f0f"/>
   <project name="meta-updater" path="layers/meta-updater" revision="f49e4acae1fad18ad43d29cb3a43300bb708fa65"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="7902664f89678164b7fc90d421cee74cbec51cdf"/>


### PR DESCRIPTION
Relevant changes:
- 31c4a0d rust: Fix build failure re-appeared on riscv32
- aa02008 rust: reproducibility issue fix with v1.75
- efb8a3d rust: Revert PGO to it's default
- 5a75b7b rust: Upgrade 1.74.1 -> 1.75.0
- 29ff1bf rust/cargo: Build fixes to rust for rv32 target
- b25cdc7 rust: Re-write RPATHs in the copies llvm-config
- 3b7898b rust: Enable rust oe-selftest.
- 46ef3d7 rust: Fix assertion failure error on oe-selftest
- 5f0c29a rust: Enable RUSTC_BOOTSTRAP to use nightly features during rust oe-selftest.
- 3dd8367 rust: detect user-specified custom targets in compiletest
- 1faf352 rust: Fetch cargo from rust-snapshot dir.