### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5e6c4068091e432ad7bc4b5c9a65cadc5bec106a"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="cd7cde41b5014c26095619f824f2d473d771ca9b"/>
   <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="8bb16533532b6abc2eded7d9961ab2a108fd7a5b"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="0dea41cd1a8eec04257a97214545c1afd1fe2aeb"/>


### PR DESCRIPTION
Relevant changes:
- cd7cde41 bsp: stm32mp: re-fix a default kernel tree name
- e5490f56 base: lmp-staging: add vendor subdir for kernel dts if needed
- 8539bd4c bsp: stm32mp: fix default kernel tree
- bb56a1ba base: linux-lmp/-rt: add recipes for kernel 6.6
- 01532e19 bsp: linux-lmp: versioning the se050-specific patch
- e44b944b base: linux-lmp-dev: Update to 6.8.0
- 3486ac43 base: wpanusb: drop recipe
- 5c3b38a0 mfgtool-files: upgrade to 1.5.179