### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9dd2ade5a33b6f4bc5e363da8d3bc79b5ffa00ed"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="56ffcacbecb0c26e46a37c246527e6d00e04e9b1"/>
   <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="5a6f7925bd2b885955c942573f70a5594f231563"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="0dea41cd1a8eec04257a97214545c1afd1fe2aeb"/>


### PR DESCRIPTION
Relevant changes:
- 56ffcacbe base: rs: Bump aklite version to f07b189f
- 7ec7a9a96 base: rc: Bump composectl ver to ebbba33
- 502ff9fb2 base: linux-lmp-rt: 6.1: bump to v6.1.90-rt30
- 3809a1258 base: linux-lmp: 6.1: bump to v6.1.90