### PR TITLE
lmp-base: update meta-lts-mixins-go layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="56ffcacbecb0c26e46a37c246527e6d00e04e9b1"/>
   <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="5a6f7925bd2b885955c942573f70a5594f231563"/>
-  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="0dea41cd1a8eec04257a97214545c1afd1fe2aeb"/>
+  <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="0ef7e7a0379f13045c2c291740dfebbeed9efd4d"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-rust" revision="1a6746a81da4d5bf2e5640fd2fa8f3ea453d40bf"/>
   <project name="meta-security" path="layers/meta-security" revision="353078bc06c8b471736daab6ed193e30d533d1f1"/>
   <project name="meta-updater" path="layers/meta-updater" revision="6c4feab2db70cb0c8ddce7e18dc7b851ad475b32"/>


### PR DESCRIPTION
Relevant changes:
- 0ef7e7a Revert "goarch: import bbclass from openembedded-core"
- f6cc1aa Revert "goarch: disable dynamic linking globally"
- e61199f conf/layer: fixup drop the linkmode completely
- 1fa4433 go: Drop the linkmode completely