### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="56ffcacbecb0c26e46a37c246527e6d00e04e9b1"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7a8266badd8803425fa8c27c94c07d6d90ba7673"/>
   <project name="meta-clang" path="layers/meta-clang" revision="312ff1c39b1bf5d35c0321e873417eb013cea477"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="5a6f7925bd2b885955c942573f70a5594f231563"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="0ef7e7a0379f13045c2c291740dfebbeed9efd4d"/>


### PR DESCRIPTION
Relevant changes:
- 7a8266bad base: systemd: switch to cgroupv2 by default
- 022868258 base: rs: Bump aklite ver to 6df80343
- 21ada1200 base: rc: Bump composectl to 1b6f1f2
- efe9acade base: lmp-feature-wifi: drop linux-firmware packages
- 0c350274d base: lmp-device-register: add HOMEPAGE description
- 48b5bca4d base: composectl: add HOMEPAGE description
- 97ae16043 base: optee-sks: bump to 048c0ca