### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5253f3b398058030329134993cafeb926d2039c6"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="e77988839dfa6806c9cb7f2ac32f59028ca07d73"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2ed384c64e206016c628451672c688e59944381b"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4052c97dc83d0c88fc277d6fc1815e0699020daa"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="6b10782a1e5760d1dd5d33d561e6367b5f971d8e"/>


### PR DESCRIPTION
Relevant changes:
- e77988839 base: rs: aktualizr: Bump version to d2cd79e
- 85c2427b7 bsp: linux-lmp-fslc: bump kernel 6.1-2.2.x-imx to 1e6abd59ab9ff1
- 3c15b8d82 Revert "Revert "base: lmp: clang: disable -mbranch-protection=standard""