### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="e77988839dfa6806c9cb7f2ac32f59028ca07d73"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="5f8d50ad13b488b49ab267364ad2c6a9896d7002"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2ed384c64e206016c628451672c688e59944381b"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4052c97dc83d0c88fc277d6fc1815e0699020daa"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="6b10782a1e5760d1dd5d33d561e6367b5f971d8e"/>


### PR DESCRIPTION
Relevant changes:
- 5f8d50ad1 linux-lmp-fslc-imx-xeno4: move patches specific to the xeno4 recipe
- 79b5b3103 bsp: u-boot-ostree-scr-fit: add boot firmware updates for am64xx-evm
- 696d8f45c bsp: am64xx: deploy tiboot3.bin for all versions of evm boards
- 76160e58b base: cryptfs: force filesystem check before resize