### PR TITLE
[backport] setup-environment-internal: Support minor releases of LmP in mirror code

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -264,6 +264,7 @@ DISTRO_DIRNAME=$(echo "${DISTRO}" | sed 's#[.-]#_#g')
 
 if [ -z "$LMP_VERSION_CACHE" ]; then
     LMP_VERSION_CACHE="$(git --git-dir ${MANIFESTS}/.git describe HEAD --tags --abbrev=0)"
+    LMP_VERSION_CACHE="$(echo $LMP_VERSION_CACHE | sed 's/\.[0-9]*$//')"
     if [ -v LMP_VERSION_CACHE_DEV ]; then
         # to use the development version of the cache the user need to define the LMP_VERSION_CACHE_DEV env
         LMP_VERSION_CACHE=$(( $LMP_VERSION_CACHE + 1 ))


### PR DESCRIPTION
We are about to release a 94.1 version of the LmP. In the event of a 94.1 tag, we want to truncate the value and still use the "94" cache. This also allows the development of "95" to continue correctly.

The drawback to this approach is that the .1 part of the sstate cache is actually in the 95 bucket. 94.1 is small enough this doesn't matter. If we ever have a minor release that causes sufficient cache invalidation, then we'll need to re-think how to produce the cache better.

Fix:
| -bash: 94.1 + 1 : syntax error: invalid arithmetic operator (error token is ".1 + 1 ")

Reference: https://github.com/foundriesio/ci-scripts/commit/36fd15a3465775e9f6627dc4b56bbe0153cb20ef

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
(cherry picked from commit 4f0305e5774de00aa035b33327bbb1ca0e3e2013)
Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>