### PR TITLE
setup-environment-internal: follows symlinks for build dir

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -35,7 +35,7 @@ if [ "$(whoami)" = "root" ]; then
     return
 fi
 
-OEROOT=$(pwd)
+OEROOT=$(readlink -f pwd)
 cd "$OEROOT"
 if [ -n "$ZSH_VERSION" ]; then
     setopt sh_word_split


### PR DESCRIPTION
Running a Yocto build from folder that contains symlinks does not work. The OE init script properly resolve all symlinks with 'readlink -f' before changing to the build dir. Let's do that in our script too.