### PR TITLE
setup-environment-internal: use readlink against the pwd output

### DIFF
--- a/setup-environment-internal
+++ b/setup-environment-internal
@@ -35,7 +35,7 @@ if [ "$(whoami)" = "root" ]; then
     return
 fi
 
-OEROOT=$(readlink -f pwd)
+OEROOT=$(readlink -f $(pwd))
 cd "$OEROOT"
 if [ -n "$ZSH_VERSION" ]; then
     setopt sh_word_split


### PR DESCRIPTION
Readlink needs to be executed against the pwd command output, otherwise it is managed as a folder name.