### PR TITLE
dockerfile: Bump ostreeuploader ver 2024.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -P /tmp https://go.dev/dl/go1.19.9.linux-amd64.tar.gz && \
 ENV PATH /usr/local/go/bin:$PATH
 
 RUN git clone https://github.com/foundriesio/ostreeuploader.git /ostreeuploader && \
-    cd /ostreeuploader && git checkout -q 2023.6 && \
+    cd /ostreeuploader && git checkout -q 2024.10 && \
     cd /ostreeuploader && make
 
 


### PR DESCRIPTION
Related changes:
- b5ed2ca push: Decrease load on server

This version is supposed to decrease a load on backend by decreasing a number of goroutine and a number of files to be processed in a single http request.