### PR TITLE
dockerfile: Bump ostreeuplaoder ver 5991933

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -P /tmp https://go.dev/dl/go1.19.9.linux-amd64.tar.gz && \
 ENV PATH /usr/local/go/bin:$PATH
 
 RUN git clone https://github.com/foundriesio/ostreeuploader.git /ostreeuploader && \
-    cd /ostreeuploader && git checkout -q 2024.10.1 && \
+    cd /ostreeuploader && git checkout -q 2024.10.2 && \
     cd /ostreeuploader && make
 
 


### PR DESCRIPTION
Relevant changes:
- 5991933 push: Decrease number of push goroutines
- 2069937 push: Decouple check and push parameters
- 8ae3560 push: Fix typo in write buffer size