### PR TITLE
dockerfile: Bump ostreeuploader ver 5cd2cf9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget -P /tmp https://go.dev/dl/go1.19.9.linux-amd64.tar.gz && \
 ENV PATH /usr/local/go/bin:$PATH
 
 RUN git clone https://github.com/foundriesio/ostreeuploader.git /ostreeuploader && \
-    cd /ostreeuploader && git checkout -q 2024.10.2 && \
+    cd /ostreeuploader && git checkout -q 2024.10.3 && \
     cd /ostreeuploader && make
 
 


### PR DESCRIPTION
Relevant changes:
- 5cd2cf9 check: Reduce a number of goroutine to check file existing