### PR TITLE
[TEST] base: Update to the latest meta-lmp

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3d00fce2f185f5efe0aaa0cf393008a12c4165f3"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="842d2d83117a16fdc2b2886d871e6cdc3300e322"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2ed384c64e206016c628451672c688e59944381b"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4052c97dc83d0c88fc277d6fc1815e0699020daa"/>
   <project name="meta-lts-mixins" path="layers/meta-lts-mixins-go" revision="6b10782a1e5760d1dd5d33d561e6367b5f971d8e"/>


### PR DESCRIPTION
Relevant changes:
- 842d2d83 base: lmp: Add diagnostic tool
- c94ebf0b base: busybox: utils: add halt and poweroff
- b16edd32 Revert "bsp: meson: backport version 0.63.3"
- 06cb4cc2 Revert "bsp: meson: fixup the imx meson backported"
- ef240b6c Revert "base: layer.conf: override compat for stm-st-stm32mp"
- 5ee212a7 bsp: imx-boot: refresh patches
- 212fc420 bsp: add generic-arm64 machine alias
- 24af16a0 bsp: freescale: cairo: drop compatibility with 1.16
- b2851f30 bsp: tegra-helper-scripts: update initrd-flash.sh fork with lastest changes
- 3f1c001c Revert "base: tpm2-pkcs11: add 1.9.0 from meta-tpm rev 13653bf"
- f31516a0 Revert "base: tpm2-tss: add 4.0.1 from meta-tpm rev e188be0"
- 3de2b4be Revert "base: tpm2-abrmd: add 3.0.0 from meta-tpm rev c06b9a1"
- 0cce840e Revert "base: tpm2-tools: add 5.5 from meta-tpm rev 1ac7c66"
- 036b2e96 base: docker-ce -> docker-moby
- 1fd4216e base: lmp: drop PREFERRED_PROVIDER_virtual/docker
- 158c76bd base: docker-ce: drop
- 23216d31 base: docker-compose: drop
- a8090ae2 base: containerd-opencontainers: drop
- 0ef3c3be base: runc-opencontainers: drop
- edf74ade base: layer: add scarthgap compatibility
- 0e93411f bsp: layer: add scarthgap compatibility
- 713f9ec6 Revert "base: ostree: as we use static linking fix it with clang"
- 627834b5 base: ostree: disable static
- 18686a39 base: ostree: rebase patches in v2024.5
- 6e9936bb base: ostree: rebase patches in v2024.4
- 267d20d2 base: ostree: rebase patches in v2024.3
- 25b41115 bsp: linux-lmp-rpi: 6.1.74 -> 6.1.77
- efed11b2 base: networkmanager: 1.44 -> 1.46
- 92f5551e base: alsa-utils: refresh patches for 1.2.11
- 536f9609 bsp: lmp-machine-custom: fix beaglebone-yocto KERNEL_DEVICETREE
- e307c772 bsp: linux-lmp-rpi: 5.15.92 -> 6.1.74
- 48d6b5b6 bsp: opensbi: 1.3 -> 1.4
- 4574433d bsp: imx-atf: fix RPROVIDES 'virtual/'
- 3f3f492b classes/recipes: Switch to use inherit_defer
- e7088a0f bsp: lmp-machine-custom: ti-generic: Ajust LICENSE_DIRECTORY for ti-soc
- c7bd8997 base/bsp: drop SDPX deploy fixes
- adf04b06 base: optee-os-fio: drop imx fio patches
- 6b23b0eb base: bluez5: 5.70 > 5.72
- 33acda18 base: distro: lmp-base: Enable minidebuginfo
- 9ac735fb base: drop openssl backported patch
- 6b5efad7 base: docker-compose: sync bbappend with oe-go-mod-autogen version
- 09a1b241 base: docker-compose: move the oe-go-mod-autogen version
- 58c0f6e3 base: ostree: rebase patches in v2023.6
- e6685509 base: ostree: rebase patches in v2023.3
- a07bc420 base: ostree: rebase patches in v2023.1
- fe1e9001 base: ostree: rebase patches in v2022.7
- 38332abf base: base-passwd: refresh patches
- 6e66adcb base: base-passwd: refresh patches
- 7c59ee6b base: bluez5: 5.69 -> 5.70
- fc4a3e5b base: bluez5: 5.68 -> 5.69
- f5f89a16 base: bluez5: refresh patches
- d636236c base: bluez5: 5.66 -> 5.68
- 531f5632 base: bluez5: refresh patches
- 7a511d1e base: bluez5: 5.65 -> 5.66
- 0edf92e8 bsp: opensbi: 1.0 -> 1.3
- 53e940df base: networkmanager: 1.40 -> 1.44
- 4a4b04d0 base: networkmanager: 1.38 -> 1.40
- 30d1a6ec base: networkmanager: 1.36 -> 1.38
- cc211978 base: systemd: upstream moves from sysconfdir to nonarch_libdir
- d307e887 base: drop PR variable
- 1365fd71 bsp: layer: add nanbield compatibility
- ca5faac1 base: layer: add nanbield compatibility
- b3962191 base: non-clangable: efivar: force gcc
- 4a22af28 bsp: linux-firmware: add SRCREV_FORMAT
- dd7fdfc8 base: systemd: upstream drop gnu-efi
- caff49e2 base: systemd: drop systemd-crypt as it is sent uptream
- 972ed473 base: systemd: drop p11kit/cryptsetup-plugins as it is sent uptream
- 0e8f30a4 base: python3-docker-compose: drop python variant
- 9959ec40 base: optee-os-fio: Fix conflicting types due to enum/integer mismatch
- 2e72b67e base: drop SRCPV variable
- 7f5716a3 base: initramfs-ostree-lmp-recovery: IMAGE_NAME_SUFFIX should by empty for initramfs
- 5eaad6b5 base: initramfs-ostree-lmp-image: IMAGE_NAME_SUFFIX should by empty for initramfs
- 72db6a66 bsp: lmp-machine-custom: generic-arm64: IMAGE_NAME_SUFFIX is now directly included
- 397835a1 base: lmp: IMAGE_NAME_SUFFIX is now directly included
- 116f1ca6 base: image-types-wicnopt: IMAGE_NAME_SUFFIX is now directly included
- 529d5c23 base: lmp: use llvm provided by clang
- d2833fd5 base: lmp-mfgtool: change integrity handling
- 4c0adf11 base: linux-lmp: change integrity handling
- 97f3fc7b bsp: lmp-machine-custom: UBOOT_PROVIDES_BOOT_CONTAINER is now chosed dynamic
- 81206a12 bsp: lmp-machine-custom: imx-boot-container override removed upstream
- b4821a22 bsp: lmp-machine-custom: explicity disable imx-boot-container
- bd0360e0 Revert "base: layer: adjust tpm-layer priority"
- 95b0fd61 base/bsp: mxm-mwifiex-setup: drop recipe and use yocto variables for this propose
- 217bafaf bsp: layer: add mickledore compatibility
- fa54381d base: layer: add mickledore compatibility
- 2291085b bsp: u-boot-xlnx: increase u-boot spl size limit
- cb24105b base: lshw: drop recipe and use a bbappend
- a4ff09ae Revert "base: ovmf: backport patches to fix nvm support with qemu"
- b0e74404 bsp: layer: add langdale compatibility
- 7210713a base: layer: add langdale compatibility
- d99211f0 Revert "base: gnu-efi: enable for riscv64"
- 3e0759ef bsp: u-boot-ti-staging: remove multiconfig common files
- a460b0a9 base: rs: Bump ostreeuploader ver 5cd2cf9
- c5b3f148 bsp: u-boot-fio: am62xx-evm: drop bootcount config
- add24ec0 base: rc: composectl: Bump to 959d245
- d69e75c0 base: rs: sotactl: Bump to 7055c9a
- 77993125 base: rs: aklite: Bump to 84f3a65
- d6b9d3fb bsp: tf-a: fix path to the combo image
- 129b2612 bsp: intel-corei7-64: default entry
- 4ac937ad base: lmp: cleanup the home/root as it is not preserved by ostree
- fc869a03 base: lmp-image-common: Do not create the user's home directory
- a135ad2f base: efitools: verify the signing keys
- fcd7286c efitools: unlock: must have UEFI_SIGN_ENABLE
- 3d038076 bsp: intel-corei7-64: provisioning/revocation menu
- 1c4ae753 base: initrd: CI encryption: use the customer's passphrase
- 604223e6 base: initramfs: check for secure boot
- 2445ef26 base: init-install-efi: installer: support encrypted rootfs
- 352caf1f base: initramfs-framework: refactor access to UEFI variables
- 026661de efitools: provide an unlock.efi solution
- ade72982 Revert "base: lmp: clang: disable -mbranch-protection=standard"
- 73ab71f9 base/bsp: drop jailhouse
- f92130de base: mfgtool-files: make it compatible with imx bsp
- eb7b3a23 bsp: ti-mfgtool-files: make it compatible with ti bsp
- fbcf51d8 bsp: stm32-mfgtool-files: make it compatible with stm bsp
- 17c2eadb bsp: drop u-boot-ti-staging-mfgtool
- 2e5e792f base: kernel-lmp-efi: check for sbsign sbverify errors
- 0388588f bsp/base:u-boot-*: Deprecate FIT_NODE_SEPARATOR
- a704f58a base: kernel-lmp-fitimage: Remove FPGA binaries
- 79209db2 base: kernel-lmp-fitimage: Deprecate FIT_NODE_SEPARATOR
- ac675337 base: rc: composectl: Bump to a738d03
- 5c1d7cfb base: rs: sotactl: Bump to a6cd327
- 1a130648 base: rs: aklite: Bump to 0a2357d
- 69e8905a base: rs: Use custom sota client dedicated repo
- 92af2e62 base: rs: aklite: Bump to 0a2357d0
- 5f0891f0 base: rc: composectl: Bump to 1b16abc
- 47083a34 base: u-boot-ostree-scr-fit: separate bootfirmware version variables
- 14b18404 base: u-boot-ostree-scr-fit: drop unneeded variable assigments
- 52eadde8 bsp: core: base-files: automount vfat boot partition
- c23ebb76 base: UEFI Secure Boot Provisioning