### PR TITLE
bsp: Deprecate STM bsp layer

### DIFF
--- a/conf/bblayers-bsp.inc
+++ b/conf/bblayers-bsp.inc
@@ -15,6 +15,5 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-tegra \
   ${OEROOT}/layers/meta-ti/meta-ti-bsp \
   ${OEROOT}/layers/meta-ti/meta-ti-extras \
-  ${OEROOT}/layers/meta-st-stm32mp \
   ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -10,7 +10,6 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="8b61684f0b1ba8bacdf3a69d993445e9791d4932"/>
   <project name="meta-intel" path="layers/meta-intel" revision="5cfefd9a8ff1f5a3534c1ba9d7d7f6971ed5d56f"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="e6d2ff0b0cbb925157c95b07327c2a7dc145fabe"/>
-  <project name="meta-st-stm32mp" path="layers/meta-st-stm32mp" revision="b0af85c466d96d5f794b125b2542b7a0ea4c91de"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="c4c74d1e575217ddc4b74759cd83186a70940ef9"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="d47fa3649b6155b9c01e06087917ddca341e7cf1"/>
   <project name="meta-ti" path="layers/meta-ti" revision="1de40ea7ee8ff136dce163b4ad1c1eddf35852a7"/>


### PR DESCRIPTION
The plan is to include it as a partner layer, this way we can better handle the versioning.