### PR TITLE
Switch all branches to track the Yocto 5.0 scarthgap release

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3d00fce2f185f5efe0aaa0cf393008a12c4165f3"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2ed384c64e206016c628451672c688e59944381b"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4052c97dc83d0c88fc277d6fc1815e0699020daa"/>
-  <project name="meta-security" path="layers/meta-security" revision="353078bc06c8b471736daab6ed193e30d533d1f1"/>
+  <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="fa550d14caebb16fede2a428ac0db66f2d0f893b"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="2ec66285d050ef3cd29a5ea57c71341e6b17b36f"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="92eea72a25e553c698bee9e3f551a5880bd4631c"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3d00fce2f185f5efe0aaa0cf393008a12c4165f3"/>
   <project name="meta-clang" path="layers/meta-clang" revision="2ed384c64e206016c628451672c688e59944381b"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="4052c97dc83d0c88fc277d6fc1815e0699020daa"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="5f9f741193f55bb4bb3c974e913d169dd23e40d3"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="fa550d14caebb16fede2a428ac0db66f2d0f893b"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="2ec66285d050ef3cd29a5ea57c71341e6b17b36f"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -10,7 +10,7 @@
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3d00fce2f185f5efe0aaa0cf393008a12c4165f3"/>
-  <project name="meta-clang" path="layers/meta-clang" revision="2ed384c64e206016c628451672c688e59944381b"/>
+  <project name="meta-clang" path="layers/meta-clang" revision="f002eb5ab051443e7b5fbc32a9505d63a67db7b6"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="5f9f741193f55bb4bb3c974e913d169dd23e40d3"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="fa550d14caebb16fede2a428ac0db66f2d0f893b"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -13,7 +13,7 @@
   <project name="meta-clang" path="layers/meta-clang" revision="2ed384c64e206016c628451672c688e59944381b"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4052c97dc83d0c88fc277d6fc1815e0699020daa"/>
   <project name="meta-security" path="layers/meta-security" revision="353078bc06c8b471736daab6ed193e30d533d1f1"/>
-  <project name="meta-updater" path="layers/meta-updater" revision="6c4feab2db70cb0c8ddce7e18dc7b851ad475b32"/>
+  <project name="meta-updater" path="layers/meta-updater" revision="fa550d14caebb16fede2a428ac0db66f2d0f893b"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="2ec66285d050ef3cd29a5ea57c71341e6b17b36f"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="92eea72a25e553c698bee9e3f551a5880bd4631c"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="353078bc06c8b471736daab6ed193e30d533d1f1"/>
   <project name="meta-updater" path="layers/meta-updater" revision="6c4feab2db70cb0c8ddce7e18dc7b851ad475b32"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="8b356b91ed0d4bcab72350a2ddcef880f4fa5c26"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="f6de96c9fa8d0b6c81c32016f342ad93c8940d9e"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="92eea72a25e553c698bee9e3f551a5880bd4631c"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="5a90927f31c4f9fccbe5d9d07d08e6e69485baa8"/>
+  <project name="bitbake" revision="f40a3a477d5241b697bf2fb030dd804c1ff5839f"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="3d00fce2f185f5efe0aaa0cf393008a12c4165f3"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9ce858389f1e9db023ceec4eb6db66973e04b471"/>
   <project name="meta-clang" path="layers/meta-clang" revision="f002eb5ab051443e7b5fbc32a9505d63a67db7b6"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="5f9f741193f55bb4bb3c974e913d169dd23e40d3"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -14,6 +14,6 @@
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4052c97dc83d0c88fc277d6fc1815e0699020daa"/>
   <project name="meta-security" path="layers/meta-security" revision="353078bc06c8b471736daab6ed193e30d533d1f1"/>
   <project name="meta-updater" path="layers/meta-updater" revision="6c4feab2db70cb0c8ddce7e18dc7b851ad475b32"/>
-  <project name="meta-virtualization" path="layers/meta-virtualization" revision="8b356b91ed0d4bcab72350a2ddcef880f4fa5c26"/>
+  <project name="meta-virtualization" path="layers/meta-virtualization" revision="2ec66285d050ef3cd29a5ea57c71341e6b17b36f"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="92eea72a25e553c698bee9e3f551a5880bd4631c"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -9,7 +9,7 @@
   <project name="meta-freescale" path="layers/meta-freescale" revision="84be484645cdcc12bc12591874bfebd24cc0c9a6"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="8b61684f0b1ba8bacdf3a69d993445e9791d4932"/>
   <project name="meta-intel" path="layers/meta-intel" revision="5cfefd9a8ff1f5a3534c1ba9d7d7f6971ed5d56f"/>
-  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="e6d2ff0b0cbb925157c95b07327c2a7dc145fabe"/>
+  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="6df7e028a2b7b2d8cab0745dc0ed2eebc3742a17"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="bd166d1fb8dc1bed7e71bd06b970a3da9149203e"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="eae16b56ccf4f761a39bfa4381ada8a4e8f952bd"/>
   <project name="meta-ti" path="layers/meta-ti" revision="4213a71a8eaed4a57562c0608f9ba29efc39eede"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="meta-arm" path="layers/meta-arm" revision="260e3adc2bf322f52d81c0642c825088a88bb051"/>
+  <project name="meta-arm" path="layers/meta-arm" revision="a8fe9d22eaefc294f91096c6a32663e2f4ab3b10"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="be9267fca85959c79b19ab65e48c8f3d7faf2b40"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="1dfc65dd2006b51d156be5bcda0e3c72c936ad0a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="0be954e82f09d235d2b5e5ea01bb62ffa8d0b5f7"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -11,6 +11,6 @@
   <project name="meta-intel" path="layers/meta-intel" revision="5cfefd9a8ff1f5a3534c1ba9d7d7f6971ed5d56f"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="e6d2ff0b0cbb925157c95b07327c2a7dc145fabe"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="c4c74d1e575217ddc4b74759cd83186a70940ef9"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="d47fa3649b6155b9c01e06087917ddca341e7cf1"/>
+  <project name="meta-tegra" path="layers/meta-tegra" revision="eae16b56ccf4f761a39bfa4381ada8a4e8f952bd"/>
   <project name="meta-ti" path="layers/meta-ti" revision="4213a71a8eaed4a57562c0608f9ba29efc39eede"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -10,7 +10,7 @@
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="8b61684f0b1ba8bacdf3a69d993445e9791d4932"/>
   <project name="meta-intel" path="layers/meta-intel" revision="5cfefd9a8ff1f5a3534c1ba9d7d7f6971ed5d56f"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="e6d2ff0b0cbb925157c95b07327c2a7dc145fabe"/>
-  <project name="meta-yocto" path="layers/meta-yocto" revision="c4c74d1e575217ddc4b74759cd83186a70940ef9"/>
+  <project name="meta-yocto" path="layers/meta-yocto" revision="bd166d1fb8dc1bed7e71bd06b970a3da9149203e"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="eae16b56ccf4f761a39bfa4381ada8a4e8f952bd"/>
   <project name="meta-ti" path="layers/meta-ti" revision="4213a71a8eaed4a57562c0608f9ba29efc39eede"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="260e3adc2bf322f52d81c0642c825088a88bb051"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="84be484645cdcc12bc12591874bfebd24cc0c9a6"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="be9267fca85959c79b19ab65e48c8f3d7faf2b40"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="1dfc65dd2006b51d156be5bcda0e3c72c936ad0a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="0be954e82f09d235d2b5e5ea01bb62ffa8d0b5f7"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="6df7e028a2b7b2d8cab0745dc0ed2eebc3742a17"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -7,7 +7,7 @@
 
   <project name="meta-arm" path="layers/meta-arm" revision="260e3adc2bf322f52d81c0642c825088a88bb051"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="84be484645cdcc12bc12591874bfebd24cc0c9a6"/>
-  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="8b61684f0b1ba8bacdf3a69d993445e9791d4932"/>
+  <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="1dfc65dd2006b51d156be5bcda0e3c72c936ad0a"/>
   <project name="meta-intel" path="layers/meta-intel" revision="0be954e82f09d235d2b5e5ea01bb62ffa8d0b5f7"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="6df7e028a2b7b2d8cab0745dc0ed2eebc3742a17"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="bd166d1fb8dc1bed7e71bd06b970a3da9149203e"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -8,7 +8,7 @@
   <project name="meta-arm" path="layers/meta-arm" revision="260e3adc2bf322f52d81c0642c825088a88bb051"/>
   <project name="meta-freescale" path="layers/meta-freescale" revision="84be484645cdcc12bc12591874bfebd24cc0c9a6"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="8b61684f0b1ba8bacdf3a69d993445e9791d4932"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="5cfefd9a8ff1f5a3534c1ba9d7d7f6971ed5d56f"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="0be954e82f09d235d2b5e5ea01bb62ffa8d0b5f7"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="6df7e028a2b7b2d8cab0745dc0ed2eebc3742a17"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="bd166d1fb8dc1bed7e71bd06b970a3da9149203e"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="eae16b56ccf4f761a39bfa4381ada8a4e8f952bd"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -12,5 +12,5 @@
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="e6d2ff0b0cbb925157c95b07327c2a7dc145fabe"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="c4c74d1e575217ddc4b74759cd83186a70940ef9"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="d47fa3649b6155b9c01e06087917ddca341e7cf1"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="1de40ea7ee8ff136dce163b4ad1c1eddf35852a7"/>
+  <project name="meta-ti" path="layers/meta-ti" revision="4213a71a8eaed4a57562c0608f9ba29efc39eede"/>
 </manifest>


### PR DESCRIPTION
This PR will provide the base release of the Linux microPlatform v95 that will support the Yocto 5.0 scarthgap release.

We will deprecate the Xilinx and STM32 bsp layers as part of the microPlatform that will now be supported in a partner layer. The meta-lts-mixins Rust and GO layers will be fully removed as they are no longer needed.

- [x] Deprecate STM in mata-lmp https://github.com/foundriesio/meta-lmp/commit/16a765ab007297d693cf695c2ae42d3d72316652
- [x] Create the [lmp-manifest/scarthgap](https://github.com/foundriesio/lmp-manifest/tree/scarthgap) from current main to exercise the new CI build scarthgap job 

The `lmp-base` distro is broken on CI and requires the https://github.com/foundriesio/ci-scripts/pull/370 which still needs to be validated again and fixed. Locally outside CI builds everything works as expected.