### PR TITLE
Scarthgap: Update stable branch oe-core and lmp

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="fa550d14caebb16fede2a428ac0db66f2d0f893b"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="79673f5c67b022e7aadeb231872470295e5b9188"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="37835788d0772568f3551532eacbf810a4a6e47b"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="61880aac34ff408a8bc5060c6140bfd086b27524"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="aea4894bbc025c145a517f3dca6102f936ec4b03"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="7657b41046ff745ce5fe61a64f615623ebb098e0"/>
   <project name="meta-clang" path="layers/meta-clang" revision="8c77b427408db01b8de4c04bd3d247c13c154f92"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4f11a12b2352bbdfafb6b7d956bf424af4992977"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -13,7 +13,7 @@
   <project name="meta-clang" path="layers/meta-clang" revision="8c77b427408db01b8de4c04bd3d247c13c154f92"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4f11a12b2352bbdfafb6b7d956bf424af4992977"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
-  <project name="meta-updater" path="layers/meta-updater" revision="fa550d14caebb16fede2a428ac0db66f2d0f893b"/>
+  <project name="meta-updater" path="layers/meta-updater" revision="92f0e7aa93966e184beb1ccdfea6c8fdb27d2b18"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="79673f5c67b022e7aadeb231872470295e5b9188"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="61880aac34ff408a8bc5060c6140bfd086b27524"/>
 </manifest>


### PR DESCRIPTION
Update the lmp-base manifest to the latest versions:
- oe-core
- meta-lmp