### PR TITLE
lmp-base: downgrade openembedded-core layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="92f0e7aa93966e184beb1ccdfea6c8fdb27d2b18"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="79673f5c67b022e7aadeb231872470295e5b9188"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="61880aac34ff408a8bc5060c6140bfd086b27524"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="62cb12967391db709315820d48853ffa4c6b4740"/>
 </manifest>


### PR DESCRIPTION
There are one issue upstream that breakes our fitimage and so we need to downgade to the previows stable yocto-5.0.7 tag to unblock the testing factories.

Relevant changes:
- 62cb129673 build-appliance-image: Update to scarthgap head revision

Relevant changes (reverted):
- 61880aac34 base-files: Drop /bin/sh dependency
- d34b38ecc2 qemu: Do not define sched_attr with glibc >= 2.41
- 234f64b64e cmake: apply parallel build settings to ptest tasks
- 9862cb44ad go: upgrade 1.22.11 -> 1.22.12
- 989dc0cea1 linux-yocto/6.6: update to v6.6.75
- 685b2719ae python3: upgrade 3.12.8 -> 3.12.9
- 3e7b7697ec gstreamer1.0-rtsp-server: fix CVE-2024-44331
- c46bb37a76 ffmpeg: fix CVE-2024-35369
- 161711ba2e ffmpeg: fix CVE-2024-36619
- 21230d5dfe ffmpeg: fix CVE-2024-36618
- 8057ba6304 ffmpeg: fix CVE-2024-36617
- fe7df1727d ffmpeg: fix CVE-2024-36616
- 5661bac10d ffmpeg: fix CVE-2024-36613
- 051bc7afc0 ffmpeg: fix CVE-2024-35365
- 7215628205 selftest/rust: correctly form the PATH environment variable
- 681f5ea8d6 oeqa/selftest/rust: skip on all MIPS platforms
- 83c3e40e23 oeqa/sdk/context: fix for gtk3 test failure during do_testsdk
- 12fd08cf40 rust: remove redundant cargo config file
- 889cda30ba rust: fix for rust multilib sdk configuration
- b71da7dd83 rust-common.bbclass: soft assignment for RUSTLIB path
- 104737073b pkg-config-native: pick additional search paths from $EXTRA_NATIVE_PKGCONFIG_PATH
- 617df4ee1d binutils: File name too long causing failure to open temporary head file in dlltool
- e00920c55a files: overlayfs-create-dirs: Improve mount unit dependency
- 9eb6c41e1c files: Amend overlayfs unit descriptions with path information
- a596d0e380 gnupg: upgrade 2.4.4 -> 2.4.5
- 54181d6ca6 glibc: stable 2.39 branch updates
- 6ce232df15 binutils: stable 2.42 branch update
- 37835788d0 uboot-config: fix devtool modify with kernel-fitimage
- f50306ea3e devtool: ide-sdk remove the plugin from eSDK installer
- 1528d6aa06 oe-selftest: devtool ide-sdk use modify debug-build
- 2379596268 devtool: ide-sdk recommend DEBUG_BUILD
- b12dbde1ea devtool: ide-sdk sort cmake preset
- fa30d8dd71 devtool: modify support debug-builds
- d7bd9c6276 u-boot: kernel-fitimage: Fix dependency loop if UBOOT_SIGN_ENABLE and UBOOT_ENV enabled
- 35bf053cd4 go: upgrade 1.22.10 -> 1.22.11
- 4d35279eed go: upgrade 1.22.9 -> 1.22.10
- a424422df9 go: upgrade 1.22.8 -> 1.22.9
- 57ca5a2c91 systemd: upgrade 255.13 -> 255.17
- 7f9bb49394 openssl: patch CVE-2024-13176