### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="9ce50f57a3d95a627bc225dac1aaf42b077f3acb"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="e3daa83ef34a37bbe82300ad232b1b128fc8fb45"/>
   <project name="meta-clang" path="layers/meta-clang" revision="8c77b427408db01b8de4c04bd3d247c13c154f92"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="6c9f1f8d4538119803bf793747b65e4d23c33544"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>


### PR DESCRIPTION
Relevant changes:
- e3daa83ef Revert "base: aktualizr: fix RDEPENDS"
- f50a43ae9 base: rs: aklite: Bump to 9034bdf
- 523102e53 base:classes: Fix path for recipeinfo license file
- 408ce397a base: optee-os-fio-se05x: disable CTR driver