### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="6d93bd151ae79c3f2bf55964ce0548a48dd696c4"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="75a201f7dd1b41760432c673d4847518ffa84e96"/>
   <project name="meta-clang" path="layers/meta-clang" revision="8c77b427408db01b8de4c04bd3d247c13c154f92"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="6c9f1f8d4538119803bf793747b65e4d23c33544"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>


### PR DESCRIPTION
Relevant changes:
- 75a201f7d bsp: linux-lmp-fslc-imx: backport fixes for imx6ull ethernet