### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="6dd063fa4d23444357f622bc04821a2dde1c520f"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="bc83905c4883911fdc53e332fb7e49d82b22bcef"/>
   <project name="meta-clang" path="layers/meta-clang" revision="8c77b427408db01b8de4c04bd3d247c13c154f92"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="6c9f1f8d4538119803bf793747b65e4d23c33544"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>


### PR DESCRIPTION
Relevant changes:
- bc83905c4 base: ostree: skip aboot entries when not available
- 683076979 bsp: lmp-machine-custom: tegra194: drop cbootargs from ostree kernel args
- 9715ff9ce Revert "base: lmp-staging: add vendor subdir for kernel dts if needed"