### PR TITLE
Update lmp-sdk container to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN apt-get update \
 		make patch repo sudo texinfo vim-tiny wget whiptail libelf-dev git-lfs screen \
 		socket corkscrew curl xz-utils tcl libtinfo5 device-tree-compiler python3-pip python3-dev \
 		tmux libncurses-dev vim zstd lz4 liblz4-tool libc6-dev \
-		awscli gosu xvfb python3-cairo python3-gi-cairo yaru-theme-icon tree rsync bzip2 \
+		awscli gosu xvfb python3-cairo python3-gi-cairo yaru-theme-icon tree rsync bzip2 docker-compose-v2 \
 	&& ln -s /usr/bin/python3 /usr/bin/python \
 	&& pip3 --no-cache-dir install expandvars jsonFormatter \
 	&& apt-get autoremove -y \
@@ -101,14 +101,3 @@ ENV FIO_CHECK_CMD /usr/bin/fiocheck
 
 # Install skopeo
 COPY --from=container-tools /skopeo/bin/skopeo /usr/bin
-
-# Install docker, v28.0.4, required by the oe-builtin App preload, `docker compose config`
-# Install docker compose CLI plugin, v2.34.0, required by the oe-builtin App preload, `docker compose config`
-# https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/
-RUN mkdir -p /etc/apt/keyrings \
-	&& curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
-	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
-	&& apt-get update && apt-get install -y \
-		docker-ce-cli=5:28.0.4-1~ubuntu.22.04~jammy \
-		docker-compose-plugin=2.34.0-1~ubuntu.22.04~jammy \
-	&& apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
requires https://github.com/foundriesio/ci-scripts/pull/382