### PR TITLE
Scarthgap: lmp-base: update openembedded-core layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="d57b19f885fe11916c91569e20288581eff512aa"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="9e040ee8dd6025558ea60ac9db60c41bfeddf221"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="45c50169fa7e34349acf3e24fc19e573cbab4e65"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="68ee8d16fa5419acba9111d3aca285be92bd93d3"/>
 </manifest>


### PR DESCRIPTION
Relevant changes:
- 68ee8d16fa glibc: Add single-threaded fast path to rand()
- 6dd125b619 libsoup: Fix CVE-2025-32914
- 9558ec2091 connman :fix CVE-2025-32743
- 9035903630 libsoup-2.4: Fix CVE-2025-32909
- 6e373ec360 libsoup-2.4: Fix CVE-2025-32906
- dfde13ecff libsoup-2.4: Fix CVE-2024-52532
- c7ab8b45b1 libsoup-2.4: Fix CVE-2024-52531
- ef1bff79d6 libsoup-2.4: Fix CVE-2024-52530