### PR TITLE
lmp-base: update meta-lmp layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="4dffdff79b4df49c683c9a7faea406595cb7e9ca"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="b29334b86d3bb62b531f9293a5c9c61de692cf71"/>
   <project name="meta-clang" path="layers/meta-clang" revision="eaa08939eaec9f620b14742ff3ac568553683034"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="e92d0173a80ea7592c866618ef5293203c50544c"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>


### PR DESCRIPTION
Relevant changes:
- b29334b86 base: kmeta-linux-lmp-6.6.y: bump to 6d8bf98
- 5a3240d69 base: kmeta-linux-lmp-6.6.y: bump to a00a749e
- 4c037a5c8 ci: backport: update to korthout/backport-action@v3
- 9a2b0cc74 bsp: intel-corei7-64: Remove linux-firmware from RRECOMMENDS
- 4f9ff127a ci: add backport github workflow
- 9c5b2c856 u-boot-fio_imx: fix uuu_bootloader_tag class inherit
- 30f8221d2 base: linux-lmp-rt: 6.6: bump to v6.6.87-rt54
- 6b9b86075 base: linux-lmp-rt: drop 6.1 based recipe
- d8bef8eb2 base: linux-lmp: 6.6: bump to v6.6.89
- 4b66c519d base: cve-lmp-extra-exclusions: drop CVE-2022-47085