### PR TITLE
lmp-base: update openembedded-core layer

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="78707d1482746507d177b70fa548db50076879dc"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="aa75703d6c459ae57b35882057e21ecf8a78f69d"/>
   <project name="meta-clang" path="layers/meta-clang" revision="eaa08939eaec9f620b14742ff3ac568553683034"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="491671faee11ea131feab5a3a451d1a01deb2ab1"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>


### PR DESCRIPTION
Align with yocto-5.0.10.

Relevant changes:
- d5342ffc57 build-appliance-image: Update to scarthgap head revision
- 56431a98ac u-boot: ensure keys are generated before assembling U-Boot FIT image
- e7420db0d7 util-linux: Add fix to isolate test fstab entries using CUSTOM_FSTAB
- 57e25585ab ffmpeg: upgrade 6.1.1 -> 6.1.2
- 9c63f1c734 binutils: set CVE_STATUS for CVE-2025-1180
- 91231813d0 libsoup: patch CVE-2025-4476
- 421d701126 ruby: fix CVE-2025-27221
- 8f54548f78 binutils: Fix CVE-2025-1179
- 8eba970123 libsoup-2.4: Fix CVE-2025-32914
- c45c8ad64a libsoup-2.4: Fix CVE-2025-32912
- 7bdeb22172 libsoup-2.4: Fix CVE-2025-32911 & CVE-2025-32913
- 0fc936f23e libsoup-2.4: Fix CVE-2025-32910
- 29d920f4c2 libatomic-ops: Update GITHUB_BASE_URI
- 180455ee76 systemd: Password agents shouldn't be optional
- c8cb463cce binutils: Fix CVE-2025-1153
- 7c963f68cb libsoup-2.4: Fix CVE-2025-46420
- 02e2f52119 glib-2.0: fix CVE-2025-4373
- 02e046149b connman :fix CVE-2025-32366
- 6565ae2b01 openssh: Fix for CVE-2025-32728