### PR TITLE
[scarthgap] lmp-bsp: update meta-freescale

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="8e0f8af90fefb03f08cd2228cde7a89902a6b37c"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="dd3733cd91f5c85db83e49edeb3c644f424b7c7a"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="90cb4c15f033042376c38f90878459089cd10576"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="70c83e96c7f75e73245cb77f1b0cada9ed4bbc6d"/>
   <project name="meta-intel" path="layers/meta-intel" revision="38e75c8c1059e5f37659c140c010eaa203238fd2"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="3b27c95c163a042f8056066ec3d27edfcc42da7f"/>


### PR DESCRIPTION
Relevant changes:
- 90cb4c15 Merge pull request #2320 from angolini/fix_kernel-module-nxp-wlan-scarthgap
- ad8957f1 kernel-module-nxp-wlan: Fix build error
- 7d7c7e2b Merge pull request #2318 from Freescale/backport-2316-to-scarthgap
- 765da3cd imx-system-manager: fix EXTRA_OEMAKE verbose parameter
- a82f138b Merge pull request #2236 from Freescale/backport-2231-to-scarthgap
- 53899219 Merge pull request #2234 from Freescale/backport-2230-to-scarthgap
- c3630a3a Merge pull request #2232 from Freescale/backport-2195-to-scarthgap
- a12537fc kernel-module-nxp-wlan: add patch to lower PRINTM_MMSG() log level
- d639ee04 imx-boot: Add BOOT_VARIANT variable at prefix to generated binaries
- 080a954b alsa-state: Add qoriq-*-bsp specific configuration
- 8df379f5 qoriq: Add qoriq-nxp-bsp / qoriq-mainline-bsp overrides
- f52fe2b7 Merge pull request #2222 from Freescale/backport-2221-to-scarthgap
- a34d93f3 asound.conf: default sample rate to 48000
- f0b2c665 Auto-update LICENSE file with current recipe licenses
- df2f3b06 Merge pull request #2220 from tq-steina/scarthgap-imx-cst
- e7057342 Revert "imx-cst: Remove it now that it is in meta-oe"
- fe533cd4 Merge pull request #2215 from Freescale/backport-2209-to-scarthgap
- 776475a7 imx-boot: add LPDDR_FW_VERSION to mkimage arguments for iMX95
- 5ea5f3a7 Auto-update LICENSE file with current recipe licenses
- 26994727 Merge pull request #2212 from Freescale/backport-2211-to-scarthgap
- a63a107a imx-vpu-hantro: Update recipes
- ba243624 Merge pull request #2205 from Freescale/backport-2204-to-scarthgap
- dc163c77 kernel-module-nxp-wlan: remove COMPATIBLE_MACHINE
- 93ad3d26 Merge pull request #2202 from Freescale/backport-2201-to-scarthgap
- 177dc38c fix(opencv): do not try to install sample files
- aa1a3c02 Auto-update LICENSE file with current recipe licenses
- 00564a62 Merge pull request #2198 from ernestvh/scarthgap-bump-firmware-imx-v8.27
- b1601f3a firmware-imx: Upgrade to v8.27
- 2311db60 fsl-eula-unpack.bbclass: Add NXP License v58
- 3db229f1 Merge pull request #2191 from Freescale/backport-2190-to-scarthgap
- 8673f982 kernel-module-nxp-wlan: Add Upstream-Status
- c3094754 Merge pull request #2187 from Freescale/backport-2186-to-scarthgap
- 3def77c4 Revert "opencv: Specify right path for <numpy/ndarrayobject.h>"
- 12ef152d Auto-update LICENSE file with current recipe licenses
- 5c042cc7 Merge pull request #2181 from mdrodrigo/topic/scarthgap-update
- 4bfe0329 Merge pull request #2183 from Freescale/backport-2182-to-scarthgap
- 56df5f87 opencv: Specify right path for <numpy/ndarrayobject.h>
- f8c8fc73 imx-base.inc: Drop redundant i.MX 91 override
- 735be5d4 imx6sllevk.conf: Use IMX_DEFAULT_BOOTLOADER
- 1e137ccb imx-mkimage: Upgrade to NXP BSP 6.6.52_2.2.0
- 1d997dd2 imx-uuc: Don't inherit autotools
- ab5c94e1 imx8qm-mek,imx8qxp-mek: Fix SERIAL_CONSOLES
- 6087dc14 imx-mcore-demos: Fix 7D
- f3487f99 imx-mcore-demos: Fix 7ULP install
- e48ba78c mcore-demos: Upgrade to 6.6.52_2.2.0
- 5d729547 optee-os: Remove upstreamed patches
- 0567ec6d u-boot: Add CVE_PRODUCT definition
- 85d9e5b0 imx-vpuwrap: fix build error
- 770b16a7 imx-vpuwrap: Update to L6.6.52_2.2.0 release
- 130003b0 imx-parser: Update to L6.6.52_2.2.0 release Bump version 4.9.1 -> 4.9.2
- 58c07f55 imx-opencl-converter: Update to L6.6.52_2.2.0 release
- 38efd593 imx-dsp: Update to L6.6.52_2.2.0 release
- cb572daa imx-alsa-plugins_git: Switch to L6.6.52-2.2.0 release branch
- 6c4cc8e0 tinycompress: update to the version used in LF6.6.52_2.2.0
- be18f730 scripts: avoid pointless LICENSE churn
- 600c2fea treewide: Remove all references to SRC_URI[md5sum] hashes
- 9f3fd09b Auto-update LICENSE file with current recipe licenses
- e6a2607c generate-license-file: Fix layer name
- a52fe28b xserver-common: Delete bbappend
- 3e3516b8 optee-os: work-around buildpaths QA error of staticdev
- 448312c3 imx-cst: Remove it now that it is in meta-oe
- 9322fa9d tinycompress: use https-protocol to download sources
- 2b585c2b gstreamer1.0-plugins-ugly: remove unbuildable default packageconfigs
- 705708b1 Auto-update LICENSE file with current recipe licenses
- 2cfd8d71 Merge pull request #2179 from Freescale/backport-2178-to-scarthgap
- 6e1da9b2 kernel-module-nxp-wlan: Apply wireless patch
- ef4468af Merge pull request #2170 from mdrodrigo/topic/scarthgap
- 375b3487 update-license-file: Filter the workflow trigger by branch and path
- b3341202 Add workflow to automatically update LICENSE file with recipe licenses
- 31031c3b Merge pull request #2166 from Livius90/scarthgap
- 0c989a06 u-boot-fslc: upgrade to v2025.01
- 7b6b02d2 Merge pull request #2164 from Freescale/backport-2163-to-scarthgap
- 0077f15c linux-fslc: 6.12.13 -> 6.12.20