### PR TITLE
bsp: Drop meta-ti as the support is migrating to partner

### DIFF
--- a/conf/bblayers-bsp.inc
+++ b/conf/bblayers-bsp.inc
@@ -13,7 +13,5 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
   ${OEROOT}/layers/meta-tegra \
-  ${OEROOT}/layers/meta-ti/meta-ti-bsp \
-  ${OEROOT}/layers/meta-ti/meta-ti-extras \
   ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -12,5 +12,4 @@
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="3b27c95c163a042f8056066ec3d27edfcc42da7f"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="7f1be5a930554ea5036d2c806aa752ae0b2de826"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="e836736de0a439c8893ede4cef6973bd6347affa"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="71f4340b0ba3b50e2a51875df3a3e020e92b5b40"/>
 </manifest>


### PR DESCRIPTION
Drop meta-ti from manifest and from bblayers as part of migration from LmP to Partner Factories.

FFTK-3839