### PR TITLE
scarthgap: imx: update to better align with lf-6.6.52-2.2.1

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="aa75703d6c459ae57b35882057e21ecf8a78f69d"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="0666151f714b05e2a8e731f57aeaa254d7692a52"/>
   <project name="meta-clang" path="layers/meta-clang" revision="eaa08939eaec9f620b14742ff3ac568553683034"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="491671faee11ea131feab5a3a451d1a01deb2ab1"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="8e0f8af90fefb03f08cd2228cde7a89902a6b37c"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="90cb4c15f033042376c38f90878459089cd10576"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="4ea1005c570ce783bb0a4130159b6af8615ce273"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="70c83e96c7f75e73245cb77f1b0cada9ed4bbc6d"/>
   <project name="meta-intel" path="layers/meta-intel" revision="38e75c8c1059e5f37659c140c010eaa203238fd2"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="3b27c95c163a042f8056066ec3d27edfcc42da7f"/>


### PR DESCRIPTION
Update meta-freescale and meta-lmp to better align with NXP lf-6.6.52-2.2.1 BSP release.