### PR TITLE
Scarthgap drop tegra ti

### DIFF
--- a/conf/bblayers-bsp.inc
+++ b/conf/bblayers-bsp.inc
@@ -12,6 +12,5 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-raspberrypi \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
-  ${OEROOT}/layers/meta-tegra \
   ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "

--- a/conf/bblayers-bsp.inc
+++ b/conf/bblayers-bsp.inc
@@ -13,7 +13,5 @@ BSPLAYERS = " \
   ${OEROOT}/layers/meta-intel \
   ${OEROOT}/layers/meta-yocto/meta-yocto-bsp \
   ${OEROOT}/layers/meta-tegra \
-  ${OEROOT}/layers/meta-ti/meta-ti-bsp \
-  ${OEROOT}/layers/meta-ti/meta-ti-extras \
   ${OEROOT}/layers/meta-lmp/meta-lmp-bsp \
 "

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="0666151f714b05e2a8e731f57aeaa254d7692a52"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="b60bba98197749f03cdb5159d26d3cd789f642ec"/>
   <project name="meta-clang" path="layers/meta-clang" revision="eaa08939eaec9f620b14742ff3ac568553683034"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="491671faee11ea131feab5a3a451d1a01deb2ab1"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -11,5 +11,4 @@
   <project name="meta-intel" path="layers/meta-intel" revision="38e75c8c1059e5f37659c140c010eaa203238fd2"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="3b27c95c163a042f8056066ec3d27edfcc42da7f"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="7f1be5a930554ea5036d2c806aa752ae0b2de826"/>
-  <project name="meta-tegra" path="layers/meta-tegra" revision="6972d5620f1d8e0e30ef381acced5ebe384e739e"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="8e0f8af90fefb03f08cd2228cde7a89902a6b37c"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="4ea1005c570ce783bb0a4130159b6af8615ce273"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="e9c4546c6dbb3039e282b6e2b2ea4a6de8e0a87d"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="70c83e96c7f75e73245cb77f1b0cada9ed4bbc6d"/>
   <project name="meta-intel" path="layers/meta-intel" revision="38e75c8c1059e5f37659c140c010eaa203238fd2"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="3b27c95c163a042f8056066ec3d27edfcc42da7f"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -12,5 +12,4 @@
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="3b27c95c163a042f8056066ec3d27edfcc42da7f"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="7f1be5a930554ea5036d2c806aa752ae0b2de826"/>
   <project name="meta-tegra" path="layers/meta-tegra" revision="6972d5620f1d8e0e30ef381acced5ebe384e739e"/>
-  <project name="meta-ti" path="layers/meta-ti" revision="71f4340b0ba3b50e2a51875df3a3e020e92b5b40"/>
 </manifest>


### PR DESCRIPTION
Drop meta-ti and meta-tegra from manifest and from bblayers as part of migration from LmP to Partner Factories.