### PR TITLE
bsp: update meta-freescale

### DIFF
--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="8e0f8af90fefb03f08cd2228cde7a89902a6b37c"/>
-  <project name="meta-freescale" path="layers/meta-freescale" revision="aba4a65809d3a2cce977f1b8b673fd6b434120e1"/>
+  <project name="meta-freescale" path="layers/meta-freescale" revision="281202125dee44b45ddd56822e43af9c007e4d3d"/>
   <project name="meta-freescale-3rdparty" path="layers/meta-freescale-3rdparty" revision="70c83e96c7f75e73245cb77f1b0cada9ed4bbc6d"/>
   <project name="meta-intel" path="layers/meta-intel" revision="b065676a83371b34559f2077d9b2f6a6ac5652f7"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="c06ccd1897194c3a193ae1792fb0f7e7ae40763b"/>


### PR DESCRIPTION
Relevant changes:
- 28120212 Auto-update LICENSE file with current recipe licenses
- 1b51ba53 Merge pull request #2382 from eghidoli/fix_firmware-imx_ver
- c5e20316 firmware-imx: Downgrade to v8.26.1
- 145c0014 Merge pull request #2379 from jviguera/scarthgap
- c9e7728d imx-system-manager: update revision to NXP's lf-6.6.52-2.2.1 release