### PR TITLE
Bump base to scarthgap 5.0.16

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="8dcf084522b9c66a6639b5f117f554fde9b6b45a"/>
+  <project name="bitbake" revision="10118785e4a670bce4980e1044c0888a8b6e84af"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="41ac060dff2e2dcbf646114f122ddf00e7c75b1d"/>
   <project name="meta-clang" path="layers/meta-clang" revision="731488911f55ebfe746068512b426351192f82f2"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="2759d8870ea387b76c902070bed8a6649ff47b56"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="4d3e2639dec542b58708244662d5ce36810fc510"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="41ac060dff2e2dcbf646114f122ddf00e7c75b1d"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="a938deb49f1bb77cb6a36f52470de39117a6f995"/>
   <project name="meta-clang" path="layers/meta-clang" revision="731488911f55ebfe746068512b426351192f82f2"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="4d3e2639dec542b58708244662d5ce36810fc510"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="a1f4ae4e569bc0e36c27c1e4651e502e54d63b28"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="fe2666749094e896736ff24d6885419905488723"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="6988157ad983978ffd6b12bcefedd4deaffdbbd1"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="a1f4ae4e569bc0e36c27c1e4651e502e54d63b28"/>
 </manifest>


### PR DESCRIPTION
bitbake: https://git.openembedded.org/bitbake/tag/?h=yocto-5.0.16

openembedded-core: https://git.openembedded.org/openembedded-core/tag/?h=yocto-5.0.16

meta-openembedded: ? -  https://github.com/openembedded/meta-openembedded/commit/4d3e2639dec542b58708244662d5ce36810fc510

and meta-lmp to lastest of today