### PR TITLE
Prepare for Yocto Project 6 Milestone 3 (YP 6.0 M3) targeting wrynose

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -12,7 +12,7 @@
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="88a00f79f2589ca56b79eb6415d2d0e059059a06"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="79f39ce6c63231d38556971c5d8c46e3aca79cdf"/>
   <project name="meta-security" path="layers/meta-security" revision="8028c573db6923525c2918724f2bd36d4a420e0b"/>
-  <project name="meta-updater" path="layers/meta-updater" revision="671d459917f140db7edf56295aa4dce8a743ea73"/>
+  <project name="meta-updater" path="layers/meta-updater" revision="399ca9f0b99a1b1fd38c27df7aa1bf21b232ba30"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="a1e1a021b49f5257d8908aa9b8c2ee9c083e674c"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="ac5e0160df78eef03470daf1f70a5f4d2dc0bac1"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="b54600e37073a83be1d0490bb16039df73f09c83"/>
+  <project name="bitbake" revision="112bddd8fc684fbdd71139429251b127739f863b"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -13,6 +13,6 @@
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="79f39ce6c63231d38556971c5d8c46e3aca79cdf"/>
   <project name="meta-security" path="layers/meta-security" revision="8028c573db6923525c2918724f2bd36d4a420e0b"/>
   <project name="meta-updater" path="layers/meta-updater" revision="399ca9f0b99a1b1fd38c27df7aa1bf21b232ba30"/>
-  <project name="meta-virtualization" path="layers/meta-virtualization" revision="a1e1a021b49f5257d8908aa9b8c2ee9c083e674c"/>
+  <project name="meta-virtualization" path="layers/meta-virtualization" revision="b8968685998a052e5bed0f68a546be800c6849ed"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="ac5e0160df78eef03470daf1f70a5f4d2dc0bac1"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -14,5 +14,5 @@
   <project name="meta-security" path="layers/meta-security" revision="8028c573db6923525c2918724f2bd36d4a420e0b"/>
   <project name="meta-updater" path="layers/meta-updater" revision="399ca9f0b99a1b1fd38c27df7aa1bf21b232ba30"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="b8968685998a052e5bed0f68a546be800c6849ed"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="ac5e0160df78eef03470daf1f70a5f4d2dc0bac1"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="acf86cc2af1d08fdf191209f1462b2eafb53d3bb"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="88a00f79f2589ca56b79eb6415d2d0e059059a06"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="e30ccebf0173085f1af166363bd88bba7debefa9"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="79f39ce6c63231d38556971c5d8c46e3aca79cdf"/>
   <project name="meta-security" path="layers/meta-security" revision="8028c573db6923525c2918724f2bd36d4a420e0b"/>
   <project name="meta-updater" path="layers/meta-updater" revision="399ca9f0b99a1b1fd38c27df7aa1bf21b232ba30"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -10,7 +10,7 @@
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="88a00f79f2589ca56b79eb6415d2d0e059059a06"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="0bc67b61ca52e85a5a882d809ba0c98d21cceac8"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="79f39ce6c63231d38556971c5d8c46e3aca79cdf"/>
   <project name="meta-security" path="layers/meta-security" revision="9e6d962250aab6e5319215f15b0201ef233c46cd"/>
   <project name="meta-updater" path="layers/meta-updater" revision="671d459917f140db7edf56295aa4dce8a743ea73"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="a1e1a021b49f5257d8908aa9b8c2ee9c083e674c"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="88a00f79f2589ca56b79eb6415d2d0e059059a06"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="79f39ce6c63231d38556971c5d8c46e3aca79cdf"/>
-  <project name="meta-security" path="layers/meta-security" revision="9e6d962250aab6e5319215f15b0201ef233c46cd"/>
+  <project name="meta-security" path="layers/meta-security" revision="8028c573db6923525c2918724f2bd36d4a420e0b"/>
   <project name="meta-updater" path="layers/meta-updater" revision="671d459917f140db7edf56295aa4dce8a743ea73"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="a1e1a021b49f5257d8908aa9b8c2ee9c083e674c"/>
   <project name="openembedded-core" path="layers/openembedded-core" revision="ac5e0160df78eef03470daf1f70a5f4d2dc0bac1"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -8,5 +8,5 @@
   <project name="meta-arm" path="layers/meta-arm" revision="37d31f41a8d5c47b1326cd0ae48b0032eb6d5e88"/>
   <project name="meta-intel" path="layers/meta-intel" revision="413f4312cd1fe3684f5a19db1dd97d0550bbef54"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="9720dc611cf38ff2990bdf0f6afa106645ca1f93"/>
-  <project name="meta-yocto" path="layers/meta-yocto" revision="31e68c7cf6a3686bedbcbdd99056bbd23dda2551"/>
+  <project name="meta-yocto" path="layers/meta-yocto" revision="d78ac7a82473df46336556149afaeac6c7fff1d3"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="meta-arm" path="layers/meta-arm" revision="8a5b2d5ed258e75ace09af41b08d432ce1e75458"/>
+  <project name="meta-arm" path="layers/meta-arm" revision="37d31f41a8d5c47b1326cd0ae48b0032eb6d5e88"/>
   <project name="meta-intel" path="layers/meta-intel" revision="ea36e10468ac23868a6e065c877dc761982238bb"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="046a23892770accf32776bd16a2bf6ad534f42eb"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="31e68c7cf6a3686bedbcbdd99056bbd23dda2551"/>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -7,6 +7,6 @@
 
   <project name="meta-arm" path="layers/meta-arm" revision="37d31f41a8d5c47b1326cd0ae48b0032eb6d5e88"/>
   <project name="meta-intel" path="layers/meta-intel" revision="413f4312cd1fe3684f5a19db1dd97d0550bbef54"/>
-  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="046a23892770accf32776bd16a2bf6ad534f42eb"/>
+  <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="9720dc611cf38ff2990bdf0f6afa106645ca1f93"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="31e68c7cf6a3686bedbcbdd99056bbd23dda2551"/>
 </manifest>

--- a/lmp-bsp.xml
+++ b/lmp-bsp.xml
@@ -6,7 +6,7 @@
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
   <project name="meta-arm" path="layers/meta-arm" revision="37d31f41a8d5c47b1326cd0ae48b0032eb6d5e88"/>
-  <project name="meta-intel" path="layers/meta-intel" revision="ea36e10468ac23868a6e065c877dc761982238bb"/>
+  <project name="meta-intel" path="layers/meta-intel" revision="413f4312cd1fe3684f5a19db1dd97d0550bbef54"/>
   <project name="meta-raspberrypi" path="layers/meta-raspberrypi" revision="046a23892770accf32776bd16a2bf6ad534f42eb"/>
   <project name="meta-yocto" path="layers/meta-yocto" revision="31e68c7cf6a3686bedbcbdd99056bbd23dda2551"/>
 </manifest>


### PR DESCRIPTION
Prepare for Yocto Project 6 Milestone 3 (YP 6.0 M3) targeting wrynose

YP 6.0 Milestone Dates (**new dates**):
2026-03-23 YP 6.0 M3 Build Date
2026-04-08 YP 6.0 M3 Release Date
2026-04-13 YP 6.0 M4 Build Date
2026-05-04 YP 6.0 M4 Release Date

The dates have been updated so the previous version of YP6.0M3 PR https://github.com/foundriesio/lmp-manifest/pull/528 merged are not correct.

YP 6.0 Milestone Dates (**old dates**):
2026-03-09 YP 6.0 M3 Build Date
2026-03-20 YP 6.0 M3 Release Date
2026-03-30 YP 6.0 M4 Build Date
2026-04-26 YP 6.0 M4 Release Date

https://wiki.yoctoproject.org/wiki/Weekly_Status