### PR TITLE
Bump 5.0.17

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="10118785e4a670bce4980e1044c0888a8b6e84af"/>
+  <project name="bitbake" revision="d3b4c352dd33fca90cd31649eda054b884478739"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="fe2666749094e896736ff24d6885419905488723"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="52380df998b3a8fe6a091f8547434a3231320a8e"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -9,7 +9,7 @@
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>
-  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="a938deb49f1bb77cb6a36f52470de39117a6f995"/>
+  <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="71886ffafc5792e2d00b62b64610fa108443d3a2"/>
   <project name="meta-clang" path="layers/meta-clang" revision="731488911f55ebfe746068512b426351192f82f2"/>
   <project name="meta-openembedded" path="layers/meta-openembedded" revision="5124ac4a658899158f4a7a2ddf1d2ca931ec7d0e"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="a938deb49f1bb77cb6a36f52470de39117a6f995"/>
   <project name="meta-clang" path="layers/meta-clang" revision="731488911f55ebfe746068512b426351192f82f2"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="4d3e2639dec542b58708244662d5ce36810fc510"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="5124ac4a658899158f4a7a2ddf1d2ca931ec7d0e"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>


### PR DESCRIPTION
Yocto Project released 5.0.17 for scarthgap on 2026-04-22. (https://lists.yoctoproject.org/g/yocto/message/66422)

We integrate these dot releases into the LmP as a way of making new CVE fixes available for our customers.

-Release Notes: https://docs.yoctoproject.org/scarthgap/migration-guides/release-notes-5.0.17.html
-bitbake: https://git.openembedded.org/bitbake/tag/?h=yocto-5.0.17
-openembedded-core: https://git.openembedded.org/openembedded-core/tag/?h=yocto-5.0.17
-meta-openembedded: ? - https://github.com/openembedded/meta-openembedded/commit/5124ac4a658899158f4a7a2ddf1d2ca931ec7d0e (Apr 15, 2026)