### PR TITLE
Bump scarthgap to 5.0.18

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="d3b4c352dd33fca90cd31649eda054b884478739"/>
+  <project name="bitbake" revision="82abbfcdbda949851a03bb2cb2049ea689564ad6"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="52380df998b3a8fe6a091f8547434a3231320a8e"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="ece80784b493c8b7493478fa2ba0dc1d6d80aa79"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="bbf24975e992a1d8b2807d2539e478aca1832b4b"/>
   <project name="meta-clang" path="layers/meta-clang" revision="731488911f55ebfe746068512b426351192f82f2"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="5124ac4a658899158f4a7a2ddf1d2ca931ec7d0e"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="b0c2c648a1af89e7a8dd4c2ec841f3bc0ed0ccb9"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>


### PR DESCRIPTION
Yocto LTS milestone bump for the **scarthgap** line (Yocto 5.0).

## Layers updated

- openembedded-core: -> yocto-5.0.18
- bitbake:           -> yocto-5.0.18
- meta-openembedded: 69 commits behind tip

## New revisions

- openembedded-core: https://git.openembedded.org/openembedded-core/commit/?id=ece80784b493c8b7493478fa2ba0dc1d6d80aa79
- bitbake:           https://git.openembedded.org/bitbake/commit/?id=82abbfcdbda949851a03bb2cb2049ea689564ad6
- meta-openembedded: https://github.com/openembedded/meta-openembedded/commit/b0c2c648a1af89e7a8dd4c2ec841f3bc0ed0ccb9
