### PR TITLE
local.conf: enable ostree commit size metadata

### DIFF
--- a/conf/local.conf
+++ b/conf/local.conf
@@ -116,3 +116,9 @@ STM32_ROT_KEY_PASSWORD ??= "foundries"
 CFS_SIGN_KEYDIR ??= "${TOPDIR}/conf/keys/cfs"
 CFS_SIGN_KEYNAME ?= "cfs-dev"
 CFS_SIGN_KEYDIR[vardepsexclude] += "TOPDIR"
+
+#
+# OSTree
+#
+# Add size metadata to OSTree commit objects, allowing update size estimation
+EXTRA_OSTREE_COMMIT += "--generate-sizes"


### PR DESCRIPTION
Add EXTRA_OSTREE_COMMIT += "--generate-sizes" so ostree commit objects include size metadata, enabling update size estimation. This adds roughly 36 bytes per referenced object to the commit object size.

---

Alternative to https://github.com/uptane/meta-updater/pull/217