### PR TITLE
Bump scarthgap to 5.0.19

### DIFF
--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -11,7 +11,7 @@
   </project>
   <project name="meta-lmp" path="layers/meta-lmp" remote="fio" revision="bbf24975e992a1d8b2807d2539e478aca1832b4b"/>
   <project name="meta-clang" path="layers/meta-clang" revision="731488911f55ebfe746068512b426351192f82f2"/>
-  <project name="meta-openembedded" path="layers/meta-openembedded" revision="b0c2c648a1af89e7a8dd4c2ec841f3bc0ed0ccb9"/>
+  <project name="meta-openembedded" path="layers/meta-openembedded" revision="ef3df29f2cfca6a9513b51ebcdccf82b6c8a836f"/>
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -15,5 +15,5 @@
   <project name="meta-security" path="layers/meta-security" revision="bc865c5276c2ab4031229916e8d7c20148dfbac3"/>
   <project name="meta-updater" path="layers/meta-updater" revision="b275153c9c8ea09e27d41db9f2faba3ebf92d2c2"/>
   <project name="meta-virtualization" path="layers/meta-virtualization" revision="d75faad37ae3cbbfe31dffaa6432553fc5450838"/>
-  <project name="openembedded-core" path="layers/openembedded-core" revision="ece80784b493c8b7493478fa2ba0dc1d6d80aa79"/>
+  <project name="openembedded-core" path="layers/openembedded-core" revision="2814f0962f56c8d1afa4de76d2895ba9b5cb767d"/>
 </manifest>

--- a/lmp-base.xml
+++ b/lmp-base.xml
@@ -5,7 +5,7 @@
 
   <default remote="lmp-mirrors" revision="master" sync-j="4"/>
 
-  <project name="bitbake" revision="82abbfcdbda949851a03bb2cb2049ea689564ad6"/>
+  <project name="bitbake" revision="0880963fea4d91a034e4a6e007d23f98658ab986"/>
   <project name="lmp-tools" path="tools/lmp-tools" remote="fio">
     <linkfile dest="setup-environment" src="setup-environment"/>
   </project>


### PR DESCRIPTION
Yocto LTS milestone bump for the **scarthgap** line (Yocto 5.0).

We integrate these dot releases into the LmP as a way of making new CVE fixes
available for our customers.

## Layers updated

- openembedded-core: -> yocto-5.0.19
- bitbake:           -> yocto-5.0.19
- meta-openembedded: 51 commits behind tip (2026-07-29)

## New revisions

- openembedded-core: https://git.openembedded.org/openembedded-core/commit/?id=2814f0962f56c8d1afa4de76d2895ba9b5cb767d
- bitbake:           https://git.openembedded.org/bitbake/commit/?id=0880963fea4d91a034e4a6e007d23f98658ab986
- meta-openembedded: https://github.com/openembedded/meta-openembedded/commit/ef3df29f2cfca6a9513b51ebcdccf82b6c8a836f

## References

- Release notes: https://docs.yoctoproject.org/scarthgap/migration-guides/release-notes-5.0.19.html
- bitbake tag: https://git.openembedded.org/bitbake/tag/?h=yocto-5.0.19
- openembedded-core tag: https://git.openembedded.org/openembedded-core/tag/?h=yocto-5.0.19
